### PR TITLE
Generate location list and populate locations in bibllist-bio related items

### DIFF
--- a/reference/locationList.xml
+++ b/reference/locationList.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+ <teiHeader>
+  <fileDesc>
+   <titleStmt>
+    <title>
+     Каталог произведений 90-томника
+    </title>
+    <respStmt>
+     <resp>
+      Идея, постановка задач, руководство
+     </resp>
+     <name>
+      Анастасия Бонч-Осмоловская, Фёкла Толстая, Борис Орехов, Тимофей Лукашевский
+     </name>
+    </respStmt>
+    <respStmt>
+     <resp>
+      Подготовка TEI/XML
+     </resp>
+     <name>
+      Мария Картышева, Евгений Можаев, Даниил Скоринкин, Елена Сидорова, Вероника Файнберг, Кирилл Милинцевич, Лев Буланов, Макар Федоров, Константин Петров
+     </name>
+    </respStmt>
+    <funder>
+     Проект «Слово Толстого»
+    </funder>
+   </titleStmt>
+   <publicationStmt>
+    <publisher>
+     <orgName>
+      Центр Digital Humanities НИУ ВШЭ, Научно-образовательный союз «Родное Слово», проект «Слово Толстого»
+     </orgName>
+    </publisher>
+    <availability>
+     <p>
+      Тексты и метатекстовая разметка доступны для свободного использования и распространения по лицензии Creative Commons Attribution Share-Alike (cc by-sa)
+     </p>
+    </availability>
+    <date from="2015" to="2022"/>
+   </publicationStmt>
+   <sourceDesc>
+    <biblStruct>
+     <monogr>
+      <author>
+       Толстой Лев Николаевич
+      </author>
+      <title level="m">
+       Собрание сочинений в 90 томах.
+      </title>
+      <imprint>
+       <pubPlace>
+        Москва
+       </pubPlace>
+       <publisher>
+        Государственное издательство «Художественная литература»
+       </publisher>
+       <date from="1928" to="1953"/>
+      </imprint>
+     </monogr>
+    </biblStruct>
+   </sourceDesc>
+  </fileDesc>
+ </teiHeader>
+ <standoff>
+  <listPlace>
+   <place xml:id="yasnaya_polyana">
+    <placeName>
+     Ясная Поляна
+    </placeName>
+    <geo>
+     54.06982302208611 37.52067675452382
+    </geo>
+   </place>
+   <place xml:id="tula">
+    <placeName>
+     Тула
+    </placeName>
+    <geo>
+     54.20506144011882 37.6189387051867
+    </geo>
+   </place>
+   <place xml:id="moskva">
+    <placeName>
+     Москва
+    </placeName>
+    <geo>
+     55.75375333635964 37.60506891099189
+    </geo>
+   </place>
+   <place xml:id="st_peterburg">
+    <placeName>
+     Санкт-Петербург
+    </placeName>
+    <geo>
+     59.944272295551016 30.380158194018524
+    </geo>
+   </place>
+   <place xml:id="kazan">
+    <placeName>
+     Казань
+    </placeName>
+    <geo>
+     55.799692434373085 49.12544114396467
+    </geo>
+   </place>
+   <place xml:id="starogladkovskaya">
+    <placeName>
+     Старогладковская
+    </placeName>
+    <geo>
+     43.6371237642032 46.41552647949428
+    </geo>
+   </place>
+   <place xml:id="pyatigorsk">
+    <placeName>
+     Пятигорск
+    </placeName>
+    <geo>
+     44.052225747566354 43.035447307953426
+    </geo>
+   </place>
+   <place xml:id="sevastopol">
+    <placeName>
+     Севастополь
+    </placeName>
+    <geo>
+     44.61276392530089 33.51436476776038
+    </geo>
+   </place>
+   <place xml:id="paris">
+    <placeName>
+     Париж
+    </placeName>
+    <geo>
+     48.85557503198109 2.3442745031331373
+    </geo>
+   </place>
+   <place xml:id="london">
+    <placeName>
+     Лондон
+    </placeName>
+    <geo>
+     51.50219015706608 -0.16039040064816087
+    </geo>
+   </place>
+   <place xml:id="geneva">
+    <placeName>
+     Женева
+    </placeName>
+    <geo>
+     46.20470379754416 6.139948025466097
+    </geo>
+   </place>
+   <place xml:id="borodino">
+    <placeName>
+     Бородино
+    </placeName>
+    <geo>
+     55.52803635930139 35.81861648361445
+    </geo>
+   </place>
+   <place xml:id="arzamas">
+    <placeName>
+     Арзамас
+    </placeName>
+    <geo>
+     55.39728974119993 43.82712858322312
+    </geo>
+   </place>
+   <place xml:id="samara">
+    <placeName>
+     Самара
+    </placeName>
+    <geo>
+     53.20108236314014 50.17170958966951
+    </geo>
+   </place>
+   <place xml:id="optina_pustyn">
+    <placeName>
+     Оптина пустынь
+    </placeName>
+    <geo>
+     54.055122011242496 35.83169214330774
+    </geo>
+   </place>
+   <place xml:id="astapovo">
+    <placeName>
+     Астапово
+    </placeName>
+    <geo>
+     53.20965637672821 39.523714523084315
+    </geo>
+   </place>
+  </listPlace>
+ </standoff>
+</TEI>

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_location_list/linkage-map.csv
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_location_list/linkage-map.csv
@@ -1,0 +1,18 @@
+Москв;1962;moskva
+Моск.;1;moskva
+Мос.;2;moskva
+Петерб;101;st_peterburg
+Ясная Поляна;70;yasnaya_polyana
+Я. П.;7302;yasnaya_polyana
+Я.П.;6;yasnaya_polyana
+Ясн.;27;yasnaya_polyana
+Тула;59;tula
+Казань;9;kazan
+Старогладковская;28;starogladkovskaya
+Пятигорск;12;pyatigorsk
+Париж;12;paris
+Лондон;2;london
+Женева;12;geneva
+Самара;6;samara
+Оптина пустынь;6;optina_pustyn
+Астапово;6;astapovo

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_location_list/location-list-template.xml
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_location_list/location-list-template.xml
@@ -1,0 +1,63 @@
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Каталог произведений 90-томника</title>
+                <respStmt>
+                    <resp>Идея, постановка задач, руководство</resp>
+                    <name>
+                        Анастасия Бонч-Осмоловская, Фёкла Толстая, Борис Орехов, Тимофей Лукашевский
+                    </name>
+                </respStmt>
+                <respStmt>
+                    <resp>
+                        Подготовка TEI/XML
+                    </resp>
+                    <name>
+                        Мария Картышева, Евгений Можаев, Даниил Скоринкин, Елена Сидорова, Вероника Файнберг, Кирилл Милинцевич, Лев Буланов, Макар Федоров, Константин Петров
+                    </name>
+                </respStmt>
+                <funder>
+                    Проект «Слово Толстого»
+                </funder>
+            </titleStmt>
+            <publicationStmt>
+                <publisher>
+                    <orgName>
+                        Центр Digital Humanities НИУ ВШЭ, Научно-образовательный союз «Родное Слово», проект «Слово Толстого»
+                    </orgName>
+                </publisher>
+                <availability>
+                    <p>
+                        Тексты и метатекстовая разметка доступны для свободного использования и распространения по лицензии Creative Commons Attribution Share-Alike (cc by-sa)
+                    </p>
+                </availability>
+                <date from="2015" to="2022"/>
+            </publicationStmt>
+            <sourceDesc>
+                <biblStruct>
+                    <monogr>
+                        <author>
+                            Толстой Лев Николаевич
+                        </author>
+                        <title level="m">
+                            Собрание сочинений в 90 томах.
+                        </title>
+                        <imprint>
+                            <pubPlace>
+                                Москва
+                            </pubPlace>
+                            <publisher>
+                                Государственное издательство «Художественная литература»
+                            </publisher>
+                            <date from="1928" to="1953"/>
+                        </imprint>
+                    </monogr>
+                </biblStruct>
+            </sourceDesc>
+        </fileDesc>
+    </teiHeader>
+    <standoff>
+        <listPlace />
+    </standoff>
+</TEI>

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_location_list/main.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_location_list/main.py
@@ -1,0 +1,183 @@
+from dataclasses import dataclass
+import os
+import sys
+
+import bs4
+import pandas as pd
+from tqdm import tqdm
+
+from tolstoy_bio.utilities.beautiful_soup import BeautifulSoupUtils
+
+
+LOCATION_LIST_XML_TEMPLATE_PATH = os.path.join(
+    os.path.dirname(__file__), "location-list-template.xml"
+)
+
+LOCATION_LIST_XML_PATH = os.path.join(
+    os.path.dirname(__file__), "../../../../reference/locationList.xml"
+)
+
+BIBLLIST_BIO_PATH = os.path.join(
+    os.path.dirname(__file__), "../../../../reference/bibllist_bio.xml"
+)
+
+LINKAGE_MAP_PATH = os.path.join(os.path.dirname(__file__), "linkage-map.csv")
+
+
+def parse_location_table_path_from_arguments() -> None:
+    arguments = sys.argv[1:]
+
+    if not arguments:
+        raise ValueError(
+            "Path to the source XLSX table expected as the first argument."
+        )
+
+    return arguments[0]
+
+
+@dataclass
+class Location:
+    id: str
+    label: str
+    latitude: str
+    longitude: str
+
+
+def parse_locations_from_xlsx_table(table_path: str) -> list[Location]:
+    table = pd.read_excel(table_path, dtype=str)
+
+    locations: list[Location] = []
+
+    for _, entry in tqdm(
+        table.iterrows(), "Parsing locations from XLSX table", len(table)
+    ):
+        locations.append(
+            Location(
+                id=entry["id"],
+                label=entry["Название локации"],
+                latitude=entry["Широта"],
+                longitude=entry["Долгота"],
+            )
+        )
+
+    return locations
+
+
+def create_xml_list_from_locations(
+    locations: list[Location], *, template_path: str, output_path: str
+) -> None:
+    template_soup: bs4.BeautifulSoup = BeautifulSoupUtils.create_soup_from_file(
+        template_path, "xml"
+    )
+
+    place_list = BeautifulSoupUtils.find_if_single_or_fail(template_soup, "listPlace")
+
+    for location in tqdm(locations, "Creating locationList.xml"):
+        place = template_soup.new_tag("place", attrs={"xml:id": location.id})
+
+        place_name = template_soup.new_tag("placeName")
+        place_name.string = location.label
+        place.append(place_name)
+
+        geo = template_soup.new_tag("geo")
+        geo.string = f"{location.latitude} {location.longitude}"
+        place.append(geo)
+
+        place_list.append(place)
+
+    template_soup.smooth()
+    BeautifulSoupUtils.prettify_and_save(template_soup, output_path)
+
+
+@dataclass
+class LocationDetectionRule:
+    location_id: str
+    trigger_substrings: list[str]
+
+
+def parse_location_detection_rules(map_csv_path: str) -> list[LocationDetectionRule]:
+    table = pd.read_csv(
+        map_csv_path, delimiter=";", names=["substring", "count", "location_id"]
+    )
+
+    entries_by_location_id = table.groupby(["location_id"])
+
+    rules: list[LocationDetectionRule] = []
+
+    for (location_id,), entries in entries_by_location_id:
+        trigger_substrings = [entry["substring"] for _, entry in entries.iterrows()]
+        rules.append(LocationDetectionRule(location_id, trigger_substrings))
+
+    return rules
+
+
+def add_locations_to_bibllist_bio(
+    *,
+    location_detection_rules: list[LocationDetectionRule],
+    bibllist_bio_path: str,
+) -> None:
+    print("Loading bibllist_bio.xml...")
+
+    bibllist_bio_soup = BeautifulSoupUtils.create_soup_from_file(
+        bibllist_bio_path, "xml"
+    )
+
+    related_items = list(bibllist_bio_soup.find_all("relatedItem"))
+
+    for related_item in tqdm(related_items, "Adding locations to related items"):
+        opener = BeautifulSoupUtils.find_if_single_or_fail(related_item, "opener")
+        opener_text = opener.text.strip()
+
+        applicable_location_ids = [
+            rule.location_id
+            for rule in location_detection_rules
+            if any(
+                trigger_substring.lower() in opener_text.lower()
+                for trigger_substring in rule.trigger_substrings
+            )
+        ]
+
+        if not applicable_location_ids:
+            continue
+
+        if len(applicable_location_ids) > 1:
+            # TODO: decide how to handle such cases
+            continue
+
+        applicable_location_id = applicable_location_ids[0]
+
+        location_relation = BeautifulSoupUtils.find_if_single_or_fail(
+            related_item, "relation", attrs={"type": "location"}
+        )
+
+        assert location_relation.attrs["ref"] == "EMPTY"
+
+        location_relation.attrs["ref"] = applicable_location_id
+
+    print("Saving bibllist_bio.xml...")
+    
+    BeautifulSoupUtils.prettify_and_save(bibllist_bio_soup, bibllist_bio_path)
+
+
+def main():
+    location_table_path = parse_location_table_path_from_arguments()
+    locations = parse_locations_from_xlsx_table(location_table_path)
+
+    create_xml_list_from_locations(
+        locations,
+        template_path=LOCATION_LIST_XML_TEMPLATE_PATH,
+        output_path=LOCATION_LIST_XML_PATH,
+    )
+
+    location_detection_rules = parse_location_detection_rules(LINKAGE_MAP_PATH)
+
+    add_locations_to_bibllist_bio(
+        location_detection_rules=location_detection_rules,
+        bibllist_bio_path=BIBLLIST_BIO_PATH,
+    )
+
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
https://gitlab.slovotolstogo.ru/slovotolstogoprojects/web-support/-/issues/26

Изменения:
1. Сгенерировал locationList.xml на основе данных из [таблицы](https://docs.google.com/spreadsheets/d/1vmCRdAQtyGYORo9mYMURQ1woO6xRK3JYWDTVNC9L0dQ/edit?gid=0#gid=0).
2. Сделал популяцию локаций в relatedItem-элементах bibllist-bio.xml на основе CSV ниже.

<details>
<summary>Правила маппинга подстрок опенеров с айдишниками локаций</summary>

```
Москв;1962;moskva
Моск.;1;moskva
Мос.;2;moskva
Петерб;101;st_peterburg
Ясная Поляна;70;yasnaya_polyana
Я. П.;7302;yasnaya_polyana
Я.П.;6;yasnaya_polyana
Ясн.;27;yasnaya_polyana
Тула;59;tula
Казань;9;kazan
Старогладковская;28;starogladkovskaya
Пятигорск;12;pyatigorsk
Париж;12;paris
Лондон;2;london
Женева;12;geneva
Самара;6;samara
Оптина пустынь;6;optina_pustyn
Астапово;6;astapovo
```
</details>

Замечания на согласование:
1. Нашлось три документа, у которых в опенерах помечено сразу несколько локаций: v52_112_114_1894_03_09, v48_046_046_1862_09_24, v67_117_A_A_Evdokimovu. В рамках PR их игнорировал.

Скрипт готов, ожидаю следующей итерации по синхронизации, чтобы применить.