### PR TITLE
Add sourceList.xml

### DIFF
--- a/reference/sourceList.xml
+++ b/reference/sourceList.xml
@@ -1,0 +1,12740 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+ <teiHeader>
+  <fileDesc>
+   <titleStmt>
+    <title>
+     Источники Гусева
+    </title>
+    <respStmt>
+     <resp>
+      Идея, постановка задач, руководство
+     </resp>
+     <name>
+      Анастасия Бонч-Осмоловская, Фёкла Толстая, Борис Орехов, Тимофей Лукашевский
+     </name>
+    </respStmt>
+    <respStmt>
+     <resp>
+      Подготовка TEI/XML
+     </resp>
+     <name>
+      Мария Картышева, Евгений Можаев, Даниил Скоринкин, Елена Сидорова, Вероника Файнберг, Кирилл Милинцевич, Лев Буланов, Макар Федоров, Константин Петров
+     </name>
+    </respStmt>
+    <funder>
+     Проект «Слово Толстого»
+    </funder>
+   </titleStmt>
+   <publicationStmt>
+    <publisher>
+     <orgName>
+      Центр Digital Humanities НИУ ВШЭ, Научно-образовательный союз «Родное Слово», проект «Слово Толстого»
+     </orgName>
+    </publisher>
+    <availability>
+     <p>
+      Тексты и метатекстовая разметка доступны для свободного использования и распространения по лицензии Creative Commons Attribution Share-Alike (cc by-sa)
+     </p>
+    </availability>
+    <date from="2015" to="2022"/>
+   </publicationStmt>
+  </fileDesc>
+ </teiHeader>
+ <standOff>
+  <list>
+   <item n="1" xml:id="Tolstoj_Lev_Nikolaevich_Azbuka_1873">
+    <title type="main">
+     «Азбука» гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     «Азбука» гр. Л. Н. Толстого // Гражданин. 1873. № 1.
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Азбука
+    </title>
+    <title level="m">
+     «Гражданин»
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1873
+     </date>
+    </imprint>
+   </item>
+   <item n="2" xml:id="Tolstoj_Lev_Nikolaevich_Azbuka_1873_b">
+    <title type="main">
+     «Азбука» гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     «Азбука» гр. Л. Н. Толстого // Детский сад. 1873. № 1.
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Азбука
+    </title>
+    <title level="m">
+     «Детский сад»
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1873
+     </date>
+    </imprint>
+   </item>
+   <item n="3" xml:id="Ot_redaktsii_1877">
+    <title type="main">
+     «От редакции» [«Русского вестника»]
+    </title>
+    <title type="bibl">
+     «От редакции» [«Русского вестника»] // Русский вестник. 1877. № 5.
+    </title>
+    <title level="a">
+     «От редакции»
+    </title>
+    <title level="m">
+     «Русский вестник»
+    </title>
+    <biblScope>
+     № 5
+    </biblScope>
+    <imprint>
+     <date>
+      1877
+     </date>
+    </imprint>
+   </item>
+   <item n="4" xml:id="Razdelnyj_akt_Tolstyh_1847_g">
+    <title type="main">
+     «Раздельный акт» Толстых 1847 г.
+    </title>
+    <title type="bibl">
+     «Раздельный акт» Толстых 1847 г. (Государственный музей Л. Н. Толстого в Москве)
+    </title>
+    <title level="a">
+     «Раздельный акт» Толстых 1847 г.
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="5" xml:id="Razdelnyj_akt_Tolstyh_1892_g">
+    <title type="main">
+     «Раздельный акт» Толстых 1892 г.
+    </title>
+    <title type="bibl">
+     «Раздельный акт» Толстых 1892 г. (Тульский областной архив; Государственный музей Л. Н. Толстого в Москве, копия)
+    </title>
+    <title level="a">
+     «Раздельный акт» Толстых 1892 г.
+    </title>
+    <repository>
+     Тульский областной архив; Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="6" xml:id="A_In_t_A_S_Suvorin_Zhurnalnye_i_bibliograficheskie_zametki_1868">
+    <title type="main">
+     А. Ин-т [А. С. Суворин]. Журнальные и библиографические заметки.
+    </title>
+    <title type="bibl">
+     А. Ин-т [А. С. Суворин]. Журнальные и библиографические заметки // Русский инвалид. 1868. № 80.
+    </title>
+    <author>
+     А. Ин-т [А. С. Суворин].
+    </author>
+    <title level="a">
+     Журнальные и библиографические заметки
+    </title>
+    <title level="m">
+     Русский инвалид
+    </title>
+    <biblScope>
+     № 80
+    </biblScope>
+    <imprint>
+     <date>
+      1868
+     </date>
+    </imprint>
+   </item>
+   <item n="7" xml:id="Avseenko_V_G_Ocherki_tekuschej_literatury_Gr_L_N_Tolstoj_1872">
+    <title type="main">
+     Авсеенко В. Г. Очерки текущей литературы. Гр. Л. Н. Толстой.
+    </title>
+    <title type="bibl">
+     Авсеенко В. Г. Очерки текущей литературы. Гр. Л. Н. Толстой. // Русский мир. 1872. № 104, 29 апреля.
+    </title>
+    <author>
+     Авсеенко В. Г.
+    </author>
+    <title level="a">
+     Очерки текущей литературы. Гр. Л. Н. Толстой
+    </title>
+    <title level="m">
+     Русский мир
+    </title>
+    <biblScope>
+     № 104, 29 апреля
+    </biblScope>
+    <imprint>
+     <date>
+      1872
+     </date>
+    </imprint>
+   </item>
+   <item n="8" xml:id="Ajnov_L_N_Tolstoj_i_pisateli_samorodki_1913">
+    <title type="main">
+     Айнов. Л. Н. Толстой и писатели-самородки.
+    </title>
+    <title type="bibl">
+     Айнов. Л. Н. Толстой и писатели-самородки // Жизнь для всех. 1913. № 5.
+    </title>
+    <author>
+     Айнов
+    </author>
+    <title level="a">
+     Л. Н. Толстой и писатели-самородки
+    </title>
+    <title level="m">
+     Жизнь для всех
+    </title>
+    <biblScope>
+     № 5
+    </biblScope>
+    <imprint>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="9" xml:id="Aksakov_Sergej_Timofeevich_Pismo_k_Turgenevu_I_S_1894">
+    <title type="main">
+     Аксаков С. Т. Письмо к Тургеневу И. С.
+    </title>
+    <title type="bibl">
+     Аксаков С. Т. Письмо к Тургеневу И. С. // Русское обозрение. 1894, № 12.
+    </title>
+    <author>
+     Аксаков Сергей Тимофеевич
+    </author>
+    <title level="a">
+     Письмо к Тургеневу И. С.
+    </title>
+    <title level="m">
+     Русское обозрение
+    </title>
+    <biblScope>
+     № 12
+    </biblScope>
+    <imprint>
+     <date>
+      1894
+     </date>
+    </imprint>
+   </item>
+   <item n="10" xml:id="Aksakov_Sergej_Timofeevich_Aksakov_Konstantin_Sergeevich_Aksakov_Ivan_Sergeevich_Pismo_k_Turgenevu_I_S_1894">
+    <title type="main">
+     Аксаковы С. Т., К. С. и И. С. Письмо к Тургеневу И. С.
+    </title>
+    <title type="bibl">
+     Аксаковы С. Т., К. С. и И. С. Письмо к Тургеневу И. С. // Русское обозрение 1894, № 12.
+    </title>
+    <author>
+     Аксаков Сергей Тимофеевич, Аксаков Константин Сергеевич, Аксаков Иван Сергеевич
+    </author>
+    <title level="a">
+     Письмо к Тургеневу И. С.
+    </title>
+    <title level="m">
+     «Русское обозрение»
+    </title>
+    <biblScope>
+     № 12
+    </biblScope>
+    <imprint>
+     <date>
+      1894
+     </date>
+    </imprint>
+   </item>
+   <item n="11" xml:id="Alekseev_V_I_Vospominanija_1948">
+    <title type="main">
+     Алексеев В. И. Воспоминания.
+    </title>
+    <title type="bibl">
+     Алексеев В. И. Воспоминания // Летописи Гос. Литературного музея. Кн. 12. М. 1948.
+    </title>
+    <author>
+     Алексеев В. И.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Летописи Гос. Литературного музея
+    </title>
+    <biblScope>
+     Кн. 12
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1948
+     </date>
+    </imprint>
+   </item>
+   <item n="12" xml:id="Alekseev_N_P_Pismo_k_Tolstomu_L_N_1929">
+    <title type="main">
+     Алексеев Н. П. Письмо к Толстому Л. Н.
+    </title>
+    <title type="bibl">
+     Алексеев Н. П. Письмо к Толстому Л. Н. // Сборник материалов для описания местностей и племен Кавказа. Вып. 46. Махач-Кала, 1929.
+    </title>
+    <author>
+     Алексеев Н. П.
+    </author>
+    <title level="a">
+     Письмо к Толстому Л. Н.
+    </title>
+    <title level="m">
+     Сборник материалов для описания местностей и племен Кавказа
+    </title>
+    <biblScope>
+     Вып. 46
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Махач-Кала
+     </pubPlace>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="13" xml:id="Alchevskaja_Hristiana_Danilovna_Peredumannoe_i_perezhitoe_1912">
+    <title type="main">
+     Алчевская X. Д. Передуманное и пережитое.
+    </title>
+    <title type="bibl">
+     Алчевская X. Д. Передуманное и пережитое. М., 1912.
+    </title>
+    <author>
+     Алчевская Христиана Даниловна
+    </author>
+    <title level="a">
+     Передуманное и пережитое
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="14" xml:id="Amfiteatrov_Aleksandr_Valentinovich_L_N_Tolstoj_1914">
+    <title type="main">
+     Амфитеатров А. В. Л. Н. Толстой.
+    </title>
+    <title type="bibl">
+     Амфитеатров А. В. Л. Н. Толстой // Амфитеатров А. В. Собрание сочинений. Т. 22. СПб., 1914.
+    </title>
+    <author>
+     Амфитеатров Александр Валентинович
+    </author>
+    <title level="a">
+     Л. Н. Толстой
+    </title>
+    <title level="m">
+     Амфитеатров А. В. Собрание сочинений
+    </title>
+    <biblScope>
+     Т. 22
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1914
+     </date>
+    </imprint>
+   </item>
+   <item n="15" xml:id="Anisimov_Sergej_Sergeevich_Ilinskij_I_V_Jasnaja_Poljana_Putevoditel_1928">
+    <title type="main">
+     Анисимов С. С. и Ильинский И. В. Ясная Поляна. Путеводитель.
+    </title>
+    <title type="bibl">
+     Анисимов С. С. и Ильинский И. В. Ясная Поляна. Путеводитель. М.–Л.: Госиздат, 1928.
+    </title>
+    <author>
+     Анисимов Сергей Сергеевич, Ильинский И.В.
+    </author>
+    <title level="a">
+     Ясная Поляна. Путеводитель
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Госиздат
+     </publisher>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="16" xml:id="Annenkov_Pavel_Vasilevich_Literaturnye_vospominanija_1909">
+    <title type="main">
+     Анненков П. В. Литературные воспоминания.
+    </title>
+    <title type="bibl">
+     Анненков П. В. Литературные воспоминания. СПб., 1909.
+    </title>
+    <author>
+     Анненков Павел Васильевич
+    </author>
+    <title level="a">
+     Литературные воспоминания
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="17" xml:id="Apostolov_Nikolaj_Nikolaevich_Lev_Tolstoj_i_russkoe_samoderzhavie_Fakty_vospominanija_dokumenty_1930">
+    <title type="main">
+     Апостолов Н. Н. Лев Толстой и русское самодержавие. Факты, воспоминания, документы.
+    </title>
+    <title type="bibl">
+     Апостолов Н. Н. Лев Толстой и русское самодержавие. Факты, воспоминания, документы. М.–Л.: Госиздат, 1930.
+    </title>
+    <author>
+     Апостолов Николай Николаевич
+    </author>
+    <title level="a">
+     Лев Толстой и русское самодержавие. Факты, воспоминания, документы
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Госиздат
+     </publisher>
+     <date>
+      1930
+     </date>
+    </imprint>
+   </item>
+   <item n="18" xml:id="Arbuzov_S_P_Vospominanija_byvshego_slugi_gr_L_N_Tolstogo_1904">
+    <title type="main">
+     Арбузов С. П. Воспоминания бывшего слуги гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Арбузов С. П. Воспоминания бывшего слуги гр. Л. Н. Толстого. М., 1904.
+    </title>
+    <author>
+     Арбузов С.П.
+    </author>
+    <title level="a">
+     Воспоминания бывшего слуги гр. Л. Н. Толстого
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1904
+     </date>
+    </imprint>
+   </item>
+   <item n="19" xml:id="Borisov_I_P_Arhiv_I_P_Borisova">
+    <title type="main">
+     Архив И. П. Борисова.
+    </title>
+    <title type="bibl">
+     Архив И. П. Борисова (Институт русской литературы РАН (Пушкинский Дом)).
+    </title>
+    <author>
+     Борисов И. П.
+    </author>
+    <title level="a">
+     Архив И. П. Борисова
+    </title>
+    <repository>
+     Институт русской литературы РАН (Пушкинский Дом)
+    </repository>
+   </item>
+   <item n="20" xml:id="Arhiv_Kazanskogo_Gosudarstvennogo_Universiteta_imeni_V_I_Uljanova_Lenina">
+    <title type="main">
+     Архив Казанского Государственного Университета имени В. И. Ульянова-Ленина.
+    </title>
+    <title type="bibl">
+     Архив Казанского Государственного Университета имени В. И. Ульянова-Ленина.
+    </title>
+    <title level="a">
+     Архив Казанского Государственного Университета имени В. И. Ульянова-Ленина
+    </title>
+   </item>
+   <item n="21" xml:id="Pogodin_M_P_Arhiv_M_P_Pogodina">
+    <title type="main">
+     Архив М. П. Погодина.
+    </title>
+    <title type="bibl">
+     Архив М. П. Погодина (Российская государственная библиотека).
+    </title>
+    <author>
+     Погодин М. П.
+    </author>
+    <title level="a">
+     Архив М. П. Погодина
+    </title>
+    <repository>
+     Российская государственная библиотека
+    </repository>
+   </item>
+   <item n="22" xml:id="Gusev_N_N_Arhiv_N_N_Guseva">
+    <title type="main">
+     Архив Н. Н. Гусева.
+    </title>
+    <title type="bibl">
+     Архив Н. Н. Гусева (Москва).
+    </title>
+    <author>
+     Гусев Н. Н.
+    </author>
+    <title level="a">
+     Архив Н. Н. Гусева
+    </title>
+    <repository>
+     Москва
+    </repository>
+   </item>
+   <item n="23" xml:id="Arhiv_osobogo_otdela_Uchenogo_komiteta_Ministerstva_narodnogo_prosveschenija_za_1874_god">
+    <title type="main">
+     Архив особого отдела Ученого комитета Министерства народного просвещения за 1874 год, журнал № 200.
+    </title>
+    <title type="bibl">
+     Архив особого отдела Ученого комитета Министерства народного просвещения за 1874 год, журнал № 200.
+    </title>
+    <title level="a">
+     Архив особого отдела Ученого комитета Министерства народного просвещения за 1874 год
+    </title>
+    <biblScope>
+     журнал № 200
+    </biblScope>
+   </item>
+   <item n="24" xml:id="Birjukov_P_I_Arhiv_P_I_Birjukova">
+    <title type="main">
+     Архив П. И. Бирюкова.
+    </title>
+    <title type="bibl">
+     Архив П. И. Бирюкова (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Бирюков П. И.
+    </author>
+    <title level="a">
+     Архив П. И. Бирюкова
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="25" xml:id="Tolstaja_S_A_Arhiv_S_A_Tolstoj">
+    <title type="main">
+     Архив С. А. Толстой.
+    </title>
+    <title type="bibl">
+     Архив С. А. Толстой (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Толстая С. А.
+    </author>
+    <title level="a">
+     Архив С. А. Толстой
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="26" xml:id="Pisma_N_A_Nekrasova_i_k_Nekrasovu_1916">
+    <title type="main">
+     Архив села Карабихи. Письма Н. А. Некрасова и к Некрасову.
+    </title>
+    <title type="bibl">
+     Архив села Карабихи. Письма Н. А. Некрасова и к Некрасову. /
+    </title>
+    <title level="a">
+     Письма Н. А. Некрасова и к Некрасову
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд-во К. Ф. Некрасова
+     </publisher>
+     <date>
+      1916
+     </date>
+    </imprint>
+   </item>
+   <item n="27" xml:id="Kuzminskaja_T_A_Arhiv_T_A_Kuzminskoj">
+    <title type="main">
+     Архив Т. А. Кузминской.
+    </title>
+    <title type="bibl">
+     Архив Т. А. Кузминской (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Кузминская Т. А.
+    </author>
+    <title level="a">
+     Архив Т. А. Кузминской
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого ).
+    </repository>
+   </item>
+   <item n="28" xml:id="Tolsaja_T_L_Arhiv_T_L_Tolstoj">
+    <title type="main">
+     Архив Т. Л. Толстой.
+    </title>
+    <title type="bibl">
+     Архив Т. Л. Толстой (Государственный музей Л. Н.Толстого в Москве).
+    </title>
+    <author>
+     Толсая Т. Л.
+    </author>
+    <title level="a">
+     Архив Т. Л. Толстой
+    </title>
+    <repository>
+     Государственный музей Л. Н.Толстого
+    </repository>
+   </item>
+   <item n="29" xml:id="Fet_A_A_Arhiv_A_A_Feta">
+    <title type="main">
+     Архив A. А. Фета.
+    </title>
+    <title type="bibl">
+     Архив A. А. Фета (Российская государственная библиотека).
+    </title>
+    <author>
+     Фет А. А.
+    </author>
+    <title level="a">
+     Архив A. А. Фета
+    </title>
+    <repository>
+     Российская государственная библиотека
+    </repository>
+   </item>
+   <item n="30" xml:id="Chertkov_V_G_Arhiv_B_G_Chertkova">
+    <title type="main">
+     Архив B. Г. Черткова.
+    </title>
+    <title type="bibl">
+     Архив B. Г. Черткова (Государственный музей Л. Н. Толстого в Москве; Центральный государственный архив литературы и искусства в Москве).
+    </title>
+    <author>
+     Чертков В. Г.
+    </author>
+    <title level="a">
+     Архив B. Г. Черткова
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого ; Центральный государственный архив литературы и искусства
+    </repository>
+   </item>
+   <item n="31" xml:id="Pismo_k_Vodfsonu_V_1887">
+    <title type="main">
+     Ауэрбах Б. Письмо к Водьфсону В.
+    </title>
+    <title type="bibl">
+     Ауэрбах Б. Письмо к Водьфсону В. // Nord und Slid. 1887, вып. 42.
+    </title>
+    <title level="a">
+     Письмо к Водьфсону В.
+    </title>
+    <title level="m">
+     Nord und Slid
+    </title>
+    <biblScope>
+     вып. 42
+    </biblScope>
+    <imprint>
+     <date>
+      1887
+     </date>
+    </imprint>
+   </item>
+   <item n="32" xml:id="Afisha_vechera_19_25_aprelja_1846_g_v_Kazani">
+    <title type="main">
+     Афиша вечера [19, 25 апреля 1846 г. в Казани].
+    </title>
+    <title type="bibl">
+     Афиша вечера [19, 25 апреля 1846 г. в Казани] (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <title level="a">
+     Афиша вечера [19, 25 апреля 1846 г. в Казани]
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="33" xml:id="Ashevskij_S_Lev_Tolstoj_kak_pedagog_v_kritike_70_h_godov_1914">
+    <title type="main">
+     Ашевский С. Лев Толстой как педагог в критике 70-х годов.
+    </title>
+    <title type="bibl">
+     Ашевский С. Лев Толстой как педагог в критике 70-х годов // Русская школа. 1914. № 12.
+    </title>
+    <author>
+     Ашевский С.
+    </author>
+    <title level="a">
+     Лев Толстой как педагог в критике 70-х годов
+    </title>
+    <title level="m">
+     Русская школа
+    </title>
+    <biblScope>
+     № 12
+    </biblScope>
+    <imprint>
+     <date>
+      1914
+     </date>
+    </imprint>
+   </item>
+   <item n="34" xml:id="Ashevskij_S_Jasnaja_Poljana_L_Tolstogo_v_kritike_60_h_godov_1913">
+    <title type="main">
+     Ашевский С. Ясная Поляна Л. Толстого в критике 60-х годов.
+    </title>
+    <title type="bibl">
+     Ашевский С. Ясная Поляна Л. Толстого в критике 60-х годов // Русская школа. 1913. №№ 10 и 11.
+    </title>
+    <author>
+     Ашевский С.
+    </author>
+    <title level="a">
+     Ясная Поляна Л. Толстого в критике 60-х годов
+    </title>
+    <title level="m">
+     Русская школа
+    </title>
+    <biblScope>
+     №№ 10 и 11
+    </biblScope>
+    <imprint>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="35" xml:id="Bazilevskij_B_A_K_tvorcheskoj_istorii_nezavershennogo_romana_L_N_Tolstogo_iz_vremen_Petra_I_1957">
+    <title type="main">
+     Базилевский Б. А. К творческой истории незавершенного романа Л. Н. Толстого из времен Петра I.
+    </title>
+    <title type="bibl">
+     Базилевский Б. А. К творческой истории незавершенного романа Л. Н. Толстого из времен Петра I // Ученые записки Калужского Гос. Пед. ин-та. Вып. 4. Калуга, 1957.
+    </title>
+    <author>
+     Базилевский Б. А.
+    </author>
+    <title level="a">
+     К творческой истории незавершенного романа Л. Н. Толстого из времен Петра I
+    </title>
+    <title level="m">
+     Ученые записки Калужского Гос. Пед. ин-та
+    </title>
+    <biblScope>
+     Вып. 4
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Калуга
+     </pubPlace>
+     <date>
+      1957
+     </date>
+    </imprint>
+   </item>
+   <item n="36" xml:id="Bazykin_T_Jasnopoljanskij_pozhar_1912">
+    <title type="main">
+     Базыкин Т. Яснополянский пожар.
+    </title>
+    <title type="bibl">
+     Базыкин Т. Яснополянский пожар // Толстовский ежегодник. 1912 г. М.: Издание Толстовского общества в Москве, 1912.
+    </title>
+    <author>
+     Базыкин Т.
+    </author>
+    <title level="a">
+     Яснополянский пожар
+    </title>
+    <title level="m">
+     Толстовский ежегодник
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Издание Толстовского общества в Москве
+     </publisher>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="37" xml:id="Baluhatyj_S_Pisemskaja_O_Spravochnik_po_Tolstomu_1928">
+    <title type="main">
+     Балухатый С. и Писемская О. Справочник по Толстому.
+    </title>
+    <title type="bibl">
+     Балухатый С. и Писемская О. Справочник по Толстому. М., 1928.
+    </title>
+    <author>
+     Балухатый С., Писемская О.
+    </author>
+    <title level="a">
+     Справочник по Толстому
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="38" xml:id="Barsukov_N_Zhizn_i_trudy_M_P_Pogodina_1910">
+    <title type="main">
+     Барсуков Н. Жизнь и труды М. П. Погодина.
+    </title>
+    <title type="bibl">
+     Барсуков Н. Жизнь и труды М. П. Погодина. Кн. 14. СПб., 1910.
+    </title>
+    <author>
+     Барсуков Н.
+    </author>
+    <title level="a">
+     Жизнь и труды М. П. Погодина
+    </title>
+    <biblScope>
+     Кн. 14
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1910
+     </date>
+    </imprint>
+   </item>
+   <item n="39" xml:id="Bahmetev_N_L_N_Tolstoj_i_tsenzura_v_80_h_godah_1908">
+    <title type="main">
+     Бахметьев Н. Л. Н. Толстой и цензура в 80-х годах.
+    </title>
+    <title type="bibl">
+     Бахметьев Н. Л. Н. Толстой и цензура в 80-х годах // Новое время. 1908. № 11694 от 1 окт.
+    </title>
+    <author>
+     Бахметьев Н.
+    </author>
+    <title level="a">
+     Л. Н. Толстой и цензура в 80-х годах
+    </title>
+    <title level="m">
+     Новое время
+    </title>
+    <biblScope>
+     № 11694
+    </biblScope>
+    <imprint>
+     <date>
+      1908
+     </date>
+    </imprint>
+   </item>
+   <item n="40" xml:id="Bers_Andrej_Evstafevich_Pisma_1927">
+    <title type="main">
+     Берс А. Е. Письма.
+    </title>
+    <title type="bibl">
+     Берс А. Е. Письма. // Толстой и о Толстом. Новые материалы. Вып. 3. М., 1927.
+    </title>
+    <author>
+     Берс Андрей Евстафьевич
+    </author>
+    <title level="a">
+     Письма
+    </title>
+    <title level="m">
+     Толстой и о Толстом. Новые материалы
+    </title>
+    <biblScope>
+     Вып. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1927
+     </date>
+    </imprint>
+   </item>
+   <item n="41" xml:id="Bers_Sofja_Andreevna_Vospominanija_o_gr_L_N_Tolstom">
+    <title type="main">
+     Берс С. А. Воспоминания о гр. Л. Н. Толстом.
+    </title>
+    <title type="bibl">
+     Берс С. А. Воспоминания о гр. Л. Н. Толстом (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Берс Софья Андреевна
+    </author>
+    <title level="a">
+     Воспоминания о гр. Л. Н. Толстом
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="42" xml:id="Bers_Sofja_Andreevna_Vospominanija_o_gr_L_N_Tolstom_1893">
+    <title type="main">
+     Берс С. А. Воспоминания о гр. Л. Н. Толстом.
+    </title>
+    <title type="bibl">
+     Берс С. А. Воспоминания о гр. Л. Н. Толстом. Смоленск, 1893.
+    </title>
+    <author>
+     Берс Софья Андреевна
+    </author>
+    <title level="a">
+     Воспоминания о гр. Л. Н. Толстом
+    </title>
+    <imprint>
+     <pubPlace>
+      Смоленск
+     </pubPlace>
+     <date>
+      1893
+     </date>
+    </imprint>
+   </item>
+   <item n="43" xml:id="Bibikov_Viktor_Ivanovich_Vospominanija_1910">
+    <title type="main">
+     Бибиков В. И. Воспоминания.
+    </title>
+    <title type="bibl">
+     Бибиков В. И. Воспоминания // Гаршин В. М. Полное собрание сочинений. Вновь просм, и доп. изд. с портр., автобиографическим очерком, воспоминаниями о В. Гаршине в разные эпохи его жизни и критич. статьями. СПб., 1910.
+    </title>
+    <author>
+     Бибиков Виктор Иванович
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Гаршин В. М. Полное собрание сочинений. Вновь просм, и доп. изд. с портр., автобиографическим очерком, воспоминаниями о В. Гаршине в разные эпохи его жизни и критич. статьями
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1910
+     </date>
+    </imprint>
+   </item>
+   <item n="44" xml:id="Biblioteka_dlja_chtenija_1857">
+    <title type="main">
+     Библиотека для чтения. 1857. № 1.
+    </title>
+    <title type="bibl">
+     Библиотека для чтения. 1857. № 1.
+    </title>
+    <title level="m">
+     Библиотека для чтения
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1857
+     </date>
+    </imprint>
+   </item>
+   <item n="45" xml:id="Birzhevye_vedomosti_1870">
+    <title type="main">
+     Биржевые ведомости. 1870. № 149.
+    </title>
+    <title type="bibl">
+     Биржевые ведомости. 1870. № 149.
+    </title>
+    <title level="m">
+     Биржевые ведомости
+    </title>
+    <biblScope>
+     № 149
+    </biblScope>
+    <imprint>
+     <date>
+      1870
+     </date>
+    </imprint>
+   </item>
+   <item n="46" xml:id="Birjukov_Pavel_Ivanovich_Biografija_L_N_Tolstogo_1906">
+    <title type="main">
+     Бирюков П. И. Биография Л. Н. Толстого. Т. 1. М.
+    </title>
+    <title type="bibl">
+     Бирюков П. И. Биография Л. Н. Толстого. Т. 1. М.: Изд. «Посредника», 1906.
+    </title>
+    <author>
+     Бирюков Павел Иванович
+    </author>
+    <title level="a">
+     Биография Л. Н. Толстого.
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. «Посредника»
+     </publisher>
+     <date>
+      1906
+     </date>
+    </imprint>
+   </item>
+   <item n="47" xml:id="Birjukov_Pavel_Ivanovich_Biografija_L_N_Tolstogo_1923">
+    <title type="main">
+     Бирюков П. И. Биография Л. Н. Толстого. Тт. 1–3.
+    </title>
+    <title type="bibl">
+     Бирюков П. И. Биография Л. Н. Толстого. Тт. 1–3. М.: Госиздат, 1923.
+    </title>
+    <author>
+     Бирюков Павел Иванович
+    </author>
+    <title level="a">
+     Биография Л. Н. Толстого
+    </title>
+    <biblScope>
+     Тт. 1–3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Госиздат
+     </publisher>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="48" xml:id="Birjukov_Pavel_Ivanovich_Moi_dva_greha_1923">
+    <title type="main">
+     Бирюков П. И. Мои два греха.
+    </title>
+    <title type="bibl">
+     Бирюков П. И. Мои два греха // Толстой. Памятники творчества и жизни. Вып. 3. М., 1923.
+    </title>
+    <author>
+     Бирюков Павел Иванович
+    </author>
+    <title level="a">
+     Мои два греха
+    </title>
+    <title level="m">
+     Толстой. Памятники творчества и жизни
+    </title>
+    <biblScope>
+     Вып. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="49" xml:id="Bitovt_Julian_Julianovich_Gr_L_N_Tolstoj_v_literature_i_iskusstve_1903">
+    <title type="main">
+     Битовт Ю. Гр. Л. Н. Толстой в литературе и искусстве. М., 1903.
+    </title>
+    <title type="bibl">
+     Битовт Ю. Гр. Л. Н. Толстой в литературе и искусстве. М., 1903.
+    </title>
+    <author>
+     Битовт Юлиан Юлианович
+    </author>
+    <title level="a">
+     Гр. Л. Н. Толстой в литературе и искусстве
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1903
+     </date>
+    </imprint>
+   </item>
+   <item n="50" xml:id="Blok_Georgij_Petrovich_Rod_Tolstyh">
+    <title type="main">
+     Блок Г. П. Род Толстых.
+    </title>
+    <title type="bibl">
+     Блок Г. П. Род Толстых (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Блок Георгий Петрович
+    </author>
+    <title level="a">
+     Род Толстых
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="51" xml:id="Bogdanovich_A_V_Tri_poslednih_samoderzhtsa_1924">
+    <title type="main">
+     Богданович А. В. Три последних самодержца.
+    </title>
+    <title type="bibl">
+     Богданович А. В. Три последних самодержца. М.–Л.: Изд. Л. Д. Френкель, 1924.
+    </title>
+    <author>
+     Богданович А. В.
+    </author>
+    <title level="a">
+     Три последних самодержца
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Изд. Л. Д. Френкель
+     </publisher>
+     <date>
+      1924
+     </date>
+    </imprint>
+   </item>
+   <item n="52" xml:id="Bogdanovich_M_N_Vostochnaja_vojna_1853_1856_1876">
+    <title type="main">
+     Богданович М. Н. Восточная война. 1853–1856. Т. 3.
+    </title>
+    <title type="bibl">
+     Богданович М. Н. Восточная война. 1853–1856. Т. 3. СПб., 1876.
+    </title>
+    <author>
+     Богданович М. Н.
+    </author>
+    <title level="a">
+     Восточная война. 1853–1856
+    </title>
+    <biblScope>
+     Т. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1876
+     </date>
+    </imprint>
+   </item>
+   <item n="53" xml:id="Borisov_I_P_Pismo_k_Turgenevu_I_S_1953">
+    <title type="main">
+     Борисов И. П. Письмо к Тургеневу И. С.
+    </title>
+    <title type="bibl">
+     Борисов И. П. Письмо к Тургеневу И. С. // Вечерний Ленинград. 1953, № 210 от 5 сентября.
+    </title>
+    <author>
+     Борисов И. П.
+    </author>
+    <title level="a">
+     Письмо к Тургеневу И. С.
+    </title>
+    <title level="m">
+     Вечерний Ленинград
+    </title>
+    <biblScope>
+     № 210 от 5 сентября
+    </biblScope>
+    <imprint>
+     <date>
+      1953
+     </date>
+    </imprint>
+   </item>
+   <item n="54" xml:id="Botkin_Vasilij_Petrovich_Turgenev_Ivan_Sergeevich_Neizdannaja_perepiska_1930">
+    <title type="main">
+     Боткин В. П. и Тургенев И. С. Неизданная переписка.
+    </title>
+    <title type="bibl">
+     Боткин В. П. и Тургенев И. С. Неизданная переписка. М.–Л.: Academia, 1930.
+    </title>
+    <author>
+     Боткин Василий Петрович, Тургенев Иван Сергеевич
+    </author>
+    <title level="a">
+     Неизданная переписка
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Academia
+     </publisher>
+     <date>
+      1930
+     </date>
+    </imprint>
+   </item>
+   <item n="55" xml:id="Botkin_Vasilija_Petrovich_O_stihotvorenijah_A_A_Feta_1857">
+    <title type="main">
+     Боткин В. П. О стихотворениях А. А. Фета.
+    </title>
+    <title type="bibl">
+     Боткин В. П. О стихотворениях А. А. Фета // Современник. 1857. № 1.
+    </title>
+    <author>
+     Боткин Василия Петрович
+    </author>
+    <title level="a">
+     О стихотворениях А. А. Фета
+    </title>
+    <title level="m">
+     Современник
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1857
+     </date>
+    </imprint>
+   </item>
+   <item n="56" xml:id="Botkin_Vasilija_Petrovich_Pismo_k_Botkinu_M_P_1923">
+    <title type="main">
+     Боткин В. П. Письмо к Боткину М. П.
+    </title>
+    <title type="bibl">
+     Боткин В. П. Письмо к Боткину М. П. // Литературная мысль. 1923, кн. II.
+    </title>
+    <author>
+     Боткин Василия Петрович
+    </author>
+    <title level="a">
+     Письмо к Боткину М. П.
+    </title>
+    <title level="m">
+     Литературная мысль
+    </title>
+    <biblScope>
+     Кн. II
+    </biblScope>
+    <imprint>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="57" xml:id="Botkin_Vasilija_Petrovich_Pismo_k_Nekrasovu_N_A_1913">
+    <title type="main">
+     Боткин В. П. Письмо к Некрасову Н. А.
+    </title>
+    <title type="bibl">
+     Боткин В. П. Письмо к Некрасову Н. А. // Голос минувшего. 1913, № 2.
+    </title>
+    <author>
+     Боткин Василия Петрович
+    </author>
+    <title level="a">
+     Письмо к Некрасову Н. А.
+    </title>
+    <title level="m">
+     Голос минувшего
+    </title>
+    <biblScope>
+     № 2
+    </biblScope>
+    <imprint>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="58" xml:id="Botkin_Vasilija_Petrovich_Pismo_k_Nekrasovu_N_A_1916">
+    <title type="main">
+     Боткин В. П. Письмо к Некрасову Н. А.
+    </title>
+    <title type="bibl">
+     Боткин В. П. Письмо к Некрасову Н. А. // Голос минувшего. 1916, № 29.
+    </title>
+    <author>
+     Боткин Василия Петрович
+    </author>
+    <title level="a">
+     Письмо к Некрасову Н. А.
+    </title>
+    <title level="m">
+     Голос минувшего
+    </title>
+    <biblScope>
+     № 29
+    </biblScope>
+    <imprint>
+     <date>
+      1916
+     </date>
+    </imprint>
+   </item>
+   <item n="59" xml:id="Bulgakov_Veniamin_Fedorovich_Dom_Lva_Nikolaevicha_Tolstogo_v_Hamovnikah_1928">
+    <title type="main">
+     Булгаков Вен. Дом Льва Николаевича Толстого в Хамовниках.
+    </title>
+    <title type="bibl">
+     Булгаков Вен. Дом Льва Николаевича Толстого в Хамовниках. М.–Л.: Госиздат, 1928.
+    </title>
+    <author>
+     Булгаков Вениамин Федорович
+    </author>
+    <title level="a">
+     Дом Льва Николаевича Толстого в Хамовниках
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Госиздат
+     </publisher>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="60" xml:id="Bulich_Nikolaj_Nikitich_Pismo_k_Grotu_N_Ja_1912">
+    <title type="main">
+     Булич Н. Н. Письмо к Гроту Н. Я.
+    </title>
+    <title type="bibl">
+     Булич Н. Н. Письмо к Гроту Н. Я. // Варшавские университетские известия. 1912. № 9.
+    </title>
+    <author>
+     Булич Николай Никитич
+    </author>
+    <title level="a">
+     Письмо к Гроту Н. Я.
+    </title>
+    <title level="m">
+     Варшавские университетские известия
+    </title>
+    <biblScope>
+     № 9
+    </biblScope>
+    <imprint>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="61" xml:id="Bunakov_Nikolaj_Fedorovich_Zapiski_1909">
+    <title type="main">
+     Бунаков Н. Ф. Записки.
+    </title>
+    <title type="bibl">
+     Бунаков Н. Ф. Записки. СПб., 1909.
+    </title>
+    <author>
+     Бунаков Николай Федорович
+    </author>
+    <title level="a">
+     Записки
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="62" xml:id="Bunin_Ivan_Andreevich_Pismo_k_Tolstomu_L_N_1956">
+    <title type="main">
+     Бунин И. А. Письмо к Толстому Л. Н.
+    </title>
+    <title type="bibl">
+     Бунин И. А. Письмо к Толстому Л. Н. // Новый мир. 1956. № 10.
+    </title>
+    <author>
+     Бунин Иван Андреевич
+    </author>
+    <title level="a">
+     Письмо к Толстому Л. Н.
+    </title>
+    <title level="m">
+     Новый мир
+    </title>
+    <biblScope>
+     № 10
+    </biblScope>
+    <imprint>
+     <date>
+      1956
+     </date>
+    </imprint>
+   </item>
+   <item n="63" xml:id="Burenin_V_P_Zhurnalistika_1872">
+    <title type="main">
+     Буренин В. П. Журналистика.
+    </title>
+    <title type="bibl">
+     Буренин В. П. Журналистика // С-Петербургские ведомости. 1872. № 123 от 6 мая.
+    </title>
+    <author>
+     Буренин В. П.
+    </author>
+    <title level="a">
+     Журналистика
+    </title>
+    <title level="m">
+     С-Петербургские ведомости
+    </title>
+    <biblScope>
+     № 123 от 6 мая
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1872
+     </date>
+    </imprint>
+   </item>
+   <item n="64" xml:id="Butovich_M_Jasnopoljanskaja_shkola_1862">
+    <title type="main">
+     Бутович М. Яснополянская школа.
+    </title>
+    <title type="bibl">
+     Бутович М. Яснополянская школа. // Ясная Поляна. 1862. № 2.
+    </title>
+    <author>
+     Бутович М.
+    </author>
+    <title level="a">
+     Яснополянская школа
+    </title>
+    <title level="m">
+     Ясная Поляна
+    </title>
+    <biblScope>
+     № 2
+    </biblScope>
+    <imprint>
+     <date>
+      1862
+     </date>
+    </imprint>
+   </item>
+   <item n="65" xml:id="Bushkanets_E_Novye_dokumenty_o_prebyvanii_L_N_Tolstogo_v_Kazanskom_universitete_1940">
+    <title type="main">
+     Бушканец Е. Новые документы о пребывании Л. Н. Толстого в Казанском университете
+    </title>
+    <title type="bibl">
+     Бушканец Е. Новые документы о пребывании Л. Н. Толстого в Казанском университете // Красная Татария. 1940, 14 ноября.
+    </title>
+    <author>
+     Бушканец Е.
+    </author>
+    <title level="a">
+     Новые документы о пребывании Л. Н. Толстого в Казанском университете
+    </title>
+    <title level="m">
+     Красная Татария
+    </title>
+    <imprint>
+     <date>
+      1940
+     </date>
+    </imprint>
+   </item>
+   <item n="66" xml:id="Byloe_1917">
+    <title type="main">
+     Былое. 1917. № 2 (24).
+    </title>
+    <title type="bibl">
+     Былое. 1917. № 2 (24).
+    </title>
+    <biblScope>
+     № 2 (24)
+    </biblScope>
+    <imprint>
+     <publisher>
+      Былое
+     </publisher>
+     <date>
+      1917
+     </date>
+    </imprint>
+   </item>
+   <item n="67" xml:id="Varneke_B_Tolstoj_i_teatr_1908">
+    <title type="main">
+     Варнеке Б. Толстой и театр.
+    </title>
+    <title type="bibl">
+     Варнеке Б. Толстой и театр // Голос Москвы. 1908. № 199 от 28 авг.
+    </title>
+    <author>
+     Варнеке Б.
+    </author>
+    <title level="a">
+     Толстой и театр
+    </title>
+    <title level="m">
+     Голос Москвы
+    </title>
+    <biblScope>
+     № 199 от 28 авг.
+    </biblScope>
+    <imprint>
+     <date>
+      1908
+     </date>
+    </imprint>
+   </item>
+   <item n="68" xml:id="Vatatsi_M_P_Byl_minuvshego_1913">
+    <title type="main">
+     Ватаци М. П. Быль минувшего.
+    </title>
+    <title type="bibl">
+     Ватаци М. П. Быль минувшего // Исторический вестник. 1913. № 5.
+    </title>
+    <author>
+     Ватаци М. П.
+    </author>
+    <title level="a">
+     Быль минувшего
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 5
+    </biblScope>
+    <imprint>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="69" xml:id="Vedomosti_moskovskoj_gorodskoj_politsii_1883">
+    <title type="main">
+     Ведомости московской городской полиции. 1883. № 253 от 22 ноября.
+    </title>
+    <title type="bibl">
+     Ведомости московской городской полиции. 1883. № 253 от 22 ноября.
+    </title>
+    <title level="a">
+     Ведомости московской городской полиции
+    </title>
+    <biblScope>
+     № 253 от 22 ноября
+    </biblScope>
+    <imprint>
+     <date>
+      1883
+     </date>
+    </imprint>
+   </item>
+   <item n="70" xml:id="Velikoj_pamjati_L_N_Tolstogo_Kazanskij_universitet_1828_1928_1928">
+    <title type="main">
+     Великой памяти Л. Н. Толстого Казанский университет. 1828–1928.
+    </title>
+    <title type="bibl">
+     Великой памяти Л. Н. Толстого Казанский университет. 1828–1928. Казань, 1928.
+    </title>
+    <title level="a">
+     Великой памяти Л. Н. Толстого Казанский университет. 1828–1928
+    </title>
+    <imprint>
+     <pubPlace>
+      Казань
+     </pubPlace>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="71" xml:id="Vestnik_Evropy_1928">
+    <title type="main">
+     Вестник Европы. 1875. № 7.
+    </title>
+    <title type="bibl">
+     Вестник Европы. 1875. № 7.
+    </title>
+    <title level="a">
+     Вестник Европы
+    </title>
+    <biblScope>
+     № 7
+    </biblScope>
+    <imprint>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="72" xml:id="Vovchok_Marko_Tvori_1956">
+    <title type="main">
+     Вовчок Марко. Твори. Т. 6.
+    </title>
+    <title type="bibl">
+     Вовчок Марко. Твори. Т. 6, Киев, 1956.
+    </title>
+    <author>
+     Вовчок Марко
+    </author>
+    <title level="a">
+     Твори
+    </title>
+    <biblScope>
+     Т. 6
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Киев
+     </pubPlace>
+     <date>
+      1956
+     </date>
+    </imprint>
+   </item>
+   <item n="73" xml:id="Voenno_istoricheskij_arhiv_v_Moskve">
+    <title type="main">
+     Военно-исторический архив в Москве.
+    </title>
+    <title type="bibl">
+     Военно-исторический архив в Москве.
+    </title>
+    <title level="a">
+     Военно-исторический архив в Москве
+    </title>
+   </item>
+   <item n="74" xml:id="Volkonskaja_E_G_Rod_knjazej_Volkonskih_1910">
+    <title type="main">
+     Волконская Е. Г. Род князей Волконских.
+    </title>
+    <title type="bibl">
+     Волконская Е. Г. Род князей Волконских. СПб., 1910.
+    </title>
+    <author>
+     Волконская Е. Г.
+    </author>
+    <title level="a">
+     Род князей Волконских
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1910
+     </date>
+    </imprint>
+   </item>
+   <item n="75" xml:id="Volkonskij_D_M_Dnevnik_1925">
+    <title type="main">
+     Волконский Д. М. Дневник.
+    </title>
+    <title type="bibl">
+     Волконский Д. М. Дневник // На чужой стороне. Прага. 1925. № 10.
+    </title>
+    <author>
+     Волконский Д. М.
+    </author>
+    <title level="a">
+     Дневник
+    </title>
+    <title level="m">
+     На чужой стороне
+    </title>
+    <biblScope>
+     № 10
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Прага
+     </pubPlace>
+     <date>
+      1925
+     </date>
+    </imprint>
+   </item>
+   <item n="76" xml:id="Vjazemskij_Petr_Andreevich_Polnoe_sobranie_sochinenij_1886">
+    <title type="main">
+     Вяземский П. А. Полное собрание сочинений. Т. 10.
+    </title>
+    <title type="bibl">
+     Вяземский П. А. Полное собрание сочинений. Т. 10. СПб., 1886.
+    </title>
+    <author>
+     Вяземский Петр Андреевич
+    </author>
+    <title level="a">
+     Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 10
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="77" xml:id="Ganzen_P_G_Pjat_dnej_v_Jasnoj_Poljane_1917">
+    <title type="main">
+     Ганзен П. Г. Пять дней в Ясной Поляне.
+    </title>
+    <title type="bibl">
+     Ганзен П. Г. Пять дней в Ясной Поляне // Исторический вестник. 1917. № 1.
+    </title>
+    <author>
+     Ганзен П. Г.
+    </author>
+    <title level="a">
+     Пять дней в Ясной Поляне
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1917
+     </date>
+    </imprint>
+   </item>
+   <item n="78" xml:id="Garshin_Vsevolod_Mihajlovich_Pisma_k_materi_1934">
+    <title type="main">
+     Гаршин В. М. Письма к матери.
+    </title>
+    <title type="bibl">
+     Гаршин В. М. Письма к матери. // Гаршин В. М. Полное собрание сочинейий. Т. 3. М.–Л., 1934.
+    </title>
+    <author>
+     Гаршин Всеволод Михайлович
+    </author>
+    <title level="a">
+     Письма к матери
+    </title>
+    <title level="m">
+     Гаршин В. М. Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <date>
+      1934
+     </date>
+    </imprint>
+   </item>
+   <item n="79" xml:id="Garshin_Vsevolod_Mihajlovich_Pismo_k_Uspenskomu_G_I_1934">
+    <title type="main">
+     Гаршин В. М. Письмо к Успенскому Г. И.
+    </title>
+    <title type="bibl">
+     Гаршин В. М. Письмо к Успенскому Г. И. // Гаршин В. М. Полное собрание сочинений. Т. 3. М.–Л., 1934.
+    </title>
+    <author>
+     Гаршин Всеволод Михайлович
+    </author>
+    <title level="a">
+     Письмо к Успенскому Г. И.
+    </title>
+    <title level="m">
+     Гаршин В. М. Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <date>
+      1934
+     </date>
+    </imprint>
+   </item>
+   <item n="80" xml:id="Garshin_E_Vospominanija_ob_I_S_Turgeneve_1883">
+    <title type="main">
+     Гаршин Е. Воспоминания об И. С. Тургеневе.
+    </title>
+    <title type="bibl">
+     Гаршин Е. Воспоминания об И. С. Тургеневе // Исторический вестник. 1883. № 11.
+    </title>
+    <author>
+     Гаршин Е.
+    </author>
+    <title level="a">
+     Воспоминания об И. С. Тургеневе
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1883
+     </date>
+    </imprint>
+   </item>
+   <item n="81" xml:id="Gertsen_Aleksandr_Ivanovich_Polnoe_sobranie_sochinenij_1919">
+    <title type="main">
+     Герцен А. И. Полное собрание сочинений. / Ред. М. К. Лемке. Т. 11.
+    </title>
+    <title type="bibl">
+     Герцен А. И. Полное собрание сочинений. / Ред. М. К. Лемке. Т. 11. Пг., 1919.
+    </title>
+    <author>
+     Герцен Александр Иванович
+    </author>
+    <editor>
+     Лемке М. К.
+    </editor>
+    <title level="a">
+     Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 11
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Пг.
+     </pubPlace>
+     <date>
+      1919
+     </date>
+    </imprint>
+   </item>
+   <item n="82" xml:id="Gertsen_Aleksandr_Ivanovich_Polnoe_sobranie_sochinenij_1917">
+    <title type="main">
+     Герцен А. И. Полное собрание сочинений. / Ред. М. К. Лемке. Т. 8.
+    </title>
+    <title type="bibl">
+     Герцен А. И. Полное собрание сочинений. / Ред. М. К. Лемке. Т. 8. Пг., 1917.
+    </title>
+    <author>
+     Герцен Александр Иванович
+    </author>
+    <editor>
+     Лемке М. К.
+    </editor>
+    <title level="a">
+     Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 8
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Пг.
+     </pubPlace>
+     <date>
+      1917
+     </date>
+    </imprint>
+   </item>
+   <item n="83" xml:id="Gertsen_Aleksandr_Ivanovich_Polnoe_sobranie_sochinenij_1919_b">
+    <title type="main">
+     Герцен А. И. Полное собрание сочинений. / Ред. М. К. Лемке. Т. 9.
+    </title>
+    <title type="bibl">
+     Герцен А. И. Полное собрание сочинений. / Ред. М. К. Лемке. Т. 9. Пг., 1919.
+    </title>
+    <author>
+     Герцен Александр Иванович
+    </author>
+    <editor>
+     Лемке М. К.
+    </editor>
+    <title level="a">
+     Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 9
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Пг.
+     </pubPlace>
+     <date>
+      1919
+     </date>
+    </imprint>
+   </item>
+   <item n="84" xml:id="Gershenzon_Mihail_Osipovich_Vospominanie_o_L_N_Tolstom_1923">
+    <title type="main">
+     Гершензон М. О. Воспоминание о Л. Н. Толстом.
+    </title>
+    <title type="bibl">
+     Гершензон М. О. Воспоминание о Л. Н. Толстом // Новые пропилеи. Вып. 1. М., 1923.
+    </title>
+    <author>
+     Гершензон Михаил Осипович
+    </author>
+    <title level="a">
+     Воспоминание о Л. Н. Толстом
+    </title>
+    <title level="m">
+     Новые пропилеи
+    </title>
+    <biblScope>
+     Вып. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="85" xml:id="Gets_F_Ob_otnoshenii_Vl_S_Soloveva_k_evrejskomu_voprosu_1902">
+    <title type="main">
+     Гец Ф. Об отношении Вл. С. Соловьева к еврейскому вопросу.
+    </title>
+    <title type="bibl">
+     Гец Ф. Об отношении Вл. С. Соловьева к еврейскому вопросу. Изд. 2-е. М., 1902.
+    </title>
+    <author>
+     Гец Ф.
+    </author>
+    <title level="a">
+     Об отношении Вл. С. Соловьева к еврейскому вопросу
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1902
+     </date>
+    </imprint>
+   </item>
+   <item n="86" xml:id="Glebov_P_N_Zapiski_1905">
+    <title type="main">
+     Глебов П. Н. Записки.
+    </title>
+    <title type="bibl">
+     Глебов П. Н. Записки // Русская старина. 1905. № 3.
+    </title>
+    <author>
+     Глебов П. Н.
+    </author>
+    <title level="a">
+     Записки
+    </title>
+    <title level="m">
+     Русская старина
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1905
+     </date>
+    </imprint>
+   </item>
+   <item n="87" xml:id="Golovachev_A_F_Korrespondentsija_o_jasnopoljanskoj_shkole_1860">
+    <title type="main">
+     Головачев А. Ф. Корреспонденция о яснополянской школе.
+    </title>
+    <title type="bibl">
+     Головачев А. Ф. Корреспонденция о яснополянской школе // Наше время. 1860. № 20 от 29 мая.
+    </title>
+    <author>
+     Головачев А. Ф
+    </author>
+    <title level="a">
+     Корреспонденция о яснополянской школе
+    </title>
+    <title level="m">
+     Наше время
+    </title>
+    <biblScope>
+     № 20 от 29 мая
+    </biblScope>
+    <imprint>
+     <date>
+      1860
+     </date>
+    </imprint>
+   </item>
+   <item n="88" xml:id="Golos_minuvshego_1913">
+    <title type="main">
+     Голос минувшего. 1913. № 11.
+    </title>
+    <title type="bibl">
+     Голос минувшего. 1913. № 11.
+    </title>
+    <title level="a">
+     Голос минувшего
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="89" xml:id="Golos_1875">
+    <title type="main">
+     Голос. 1875. № 173.
+    </title>
+    <title type="bibl">
+     Голос. 1875. № 173.
+    </title>
+    <title level="a">
+     Голос
+    </title>
+    <biblScope>
+     № 173
+    </biblScope>
+    <imprint>
+     <date>
+      1875
+     </date>
+    </imprint>
+   </item>
+   <item n="90" xml:id="Goldenvejzer_Aleksandr_Borisovich_Vblizi_Tolstogo_1922">
+    <title type="main">
+     Гольденвейзер А. Б. Вблизи Толстого. Т. 1.
+    </title>
+    <title type="bibl">
+     Гольденвейзер А. Б. Вблизи Толстого. Т. 1, М., 1922.
+    </title>
+    <author>
+     Гольденвейзер Александр Борисович
+    </author>
+    <title level="a">
+     Вблизи Толстого
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1922
+     </date>
+    </imprint>
+   </item>
+   <item n="91" xml:id="Goldenvejzer_Aleksandr_Borisovich_Tolstoj_i_muzyka_1939">
+    <title type="main">
+     Гольденвейзер А. Б. Толстой и музыка.
+    </title>
+    <title type="bibl">
+     Гольденвейзер А. Б. Толстой и музыка // Литературное наследство. № 37–38. М., 1939.
+    </title>
+    <author>
+     Гольденвейзер Александр Борисович
+    </author>
+    <title level="a">
+     Толстой и музыка
+    </title>
+    <biblScope>
+     № 37–38
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1939
+     </date>
+    </imprint>
+   </item>
+   <item n="92" xml:id="Goltsev_V_A_O_prekrasnom_v_iskusstve_1889">
+    <title type="main">
+     Гольцев В. А. О прекрасном в искусстве.
+    </title>
+    <title type="bibl">
+     Гольцев В. А. О прекрасном в искусстве // Русская мысль. 1889. № 9.
+    </title>
+    <author>
+     Гольцев В. А.
+    </author>
+    <title level="a">
+     О прекрасном в искусстве
+    </title>
+    <title level="m">
+     Русская мысль
+    </title>
+    <biblScope>
+     № 9
+    </biblScope>
+    <imprint>
+     <date>
+      1889
+     </date>
+    </imprint>
+   </item>
+   <item n="93" xml:id="Goncharov_i_Turgenev_Neizdannye_materialy_1923">
+    <title type="main">
+     Гончаров и Тургенев. Неизданные материалы.
+    </title>
+    <title type="bibl">
+     Гончаров и Тургенев. Неизданные материалы. Пг., 1923.
+    </title>
+    <title level="a">
+     Гончаров и Тургенев. Неизданные материалы
+    </title>
+    <imprint>
+     <pubPlace>
+      Пг.
+     </pubPlace>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="94" xml:id="Gorbunov_I_F_Sochinenija_1904_1907">
+    <title type="main">
+     Горбунов И. Ф. Сочинения. Тт. 1–3.
+    </title>
+    <title type="bibl">
+     Горбунов И. Ф. Сочинения. Тт. 1–3. СПб., 1904–1907.
+    </title>
+    <author>
+     Горбунов И. Ф.
+    </author>
+    <title level="a">
+     Сочинения
+    </title>
+    <biblScope>
+     Тт. 1–3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1904–1907
+     </date>
+    </imprint>
+   </item>
+   <item n="95" xml:id="Gorkij_Maksim_Vremja_Korolenko_1951">
+    <title type="main">
+     Горький М. Время Короленко.
+    </title>
+    <title type="bibl">
+     Горький М. Время Короленко // Горький А. М. Собрание сочинений. Т. 15. 1951.
+    </title>
+    <author>
+     Горький Максим
+    </author>
+    <title level="a">
+     Время Короленко
+    </title>
+    <title level="m">
+     Горький А. М. Собрание сочинений
+    </title>
+    <biblScope>
+     Т. 15
+    </biblScope>
+    <imprint>
+     <date>
+      1951
+     </date>
+    </imprint>
+   </item>
+   <item n="96" xml:id="Gramotej_1875">
+    <title type="main">
+     Грамотей. 1875. № 9.
+    </title>
+    <title type="bibl">
+     Грамотей. 1875. № 9.
+    </title>
+    <title level="a">
+     Грамотей
+    </title>
+    <biblScope>
+     № 9
+    </biblScope>
+    <imprint>
+     <date>
+      1875
+     </date>
+    </imprint>
+   </item>
+   <item n="97" xml:id="Gribovskij_V_U_gr_L_N_Tolstogo_1886">
+    <title type="main">
+     Грибовский В. У гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Грибовский В. У гр. Л. Н. Толстого // Неделя. 1886. № 33 от 17 августа.
+    </title>
+    <author>
+     Грибовский В.
+    </author>
+    <title level="a">
+     У гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Неделя
+    </title>
+    <biblScope>
+     № 33 от 17 августа
+    </biblScope>
+    <imprint>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="98" xml:id="Gribovskij_V_U_gr_L_N_Tolstogo_1886_b">
+    <title type="main">
+     Грибовский В. У гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Грибовский В. У гр. Л. Н. Толстого // Неделя. 1886. № 34 от 24 августа.
+    </title>
+    <author>
+     Грибовский В.
+    </author>
+    <title level="a">
+     У гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Неделя
+    </title>
+    <biblScope>
+     № 34 от 24 августа
+    </biblScope>
+    <imprint>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="99" xml:id="Grigorovich_Dmitrij_Vasilevich_Polnoe_sobranie_sochinenij_1896">
+    <title type="main">
+     Григорович Д. В. Полное собрание сочинений. Т. 12. Литературные воспоминания.
+    </title>
+    <title type="bibl">
+     Григорович Д. В. Полное собрание сочинений. Т. 12. Литературные воспоминания. СПб., 1896.
+    </title>
+    <author>
+     Григорович Дмитрий Васильевич
+    </author>
+    <title level="a">
+     Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 12
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1896
+     </date>
+    </imprint>
+   </item>
+   <item n="100" xml:id="Grigorev_Apollon_Aleksandrovich_Materialy_dlja_ego_biografii_1917">
+    <title type="main">
+     Григорьев А. А. Материалы для его биографии.
+    </title>
+    <title type="bibl">
+     Григорьев А. А. Материалы для его биографии. СПб., 1917.
+    </title>
+    <author>
+     Григорьев Аполлон Александрович
+    </author>
+    <title level="a">
+     Материалы для его биографии
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1917
+     </date>
+    </imprint>
+   </item>
+   <item n="101" xml:id="Gruzinskij_A_E_Istochniki_rasskaza_L_N_Tolstogo_Gde_ljubov_tam_i_bog_1913">
+    <title type="main">
+     Грузинский А. Е. Источники рассказа Л. Н. Толстого «Где любовь, там и бог».
+    </title>
+    <title type="bibl">
+     Грузинский А. Е. Источники рассказа Л. Н. Толстого «Где любовь, там и бог» // Голос минувшего. 1913. № 3.
+    </title>
+    <author>
+     Грузинский А. Е.
+    </author>
+    <title level="a">
+     Источники рассказа Л. Н. Толстого «Где любовь, там и бог»
+    </title>
+    <title level="m">
+     Голос минувшего
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="102" xml:id="Gudzij_N_K_Opisanie_rukopisej_romana_Anna_Karenina_1939">
+    <title type="main">
+     Гудзий Н. К. Описание рукописей романа «Анна Каренина».
+    </title>
+    <title type="bibl">
+     Гудзий Н. К. Описание рукописей романа «Анна Каренина» // Толстой Л. Н. Полное собрание сочинений. Юбилейное издание. Т. 20. 1939.
+    </title>
+    <author>
+     Гудзий Н. К.
+    </author>
+    <title level="a">
+     Описание рукописей романа «Анна Каренина»
+    </title>
+    <title level="m">
+     Толстой Л. Н. Полное собрание сочинений. Юбилейное издание
+    </title>
+    <biblScope>
+     Т. 20
+    </biblScope>
+    <imprint>
+     <date>
+      1939
+     </date>
+    </imprint>
+   </item>
+   <item n="103" xml:id="Gusev_Nikolaj_Nikolaevich_Avtorskie_ispravlenija_Vojny_i_mira_1948">
+    <title type="main">
+     Гусев Н. Н. Авторские исправления «Войны и мира».
+    </title>
+    <title type="bibl">
+     Гусев Н. Н. Авторские исправления «Войны и мира» // Летописи Государственного Литературного музея. Кн. 12. М., 1948.
+    </title>
+    <author>
+     Гусев Николай Николаевич
+    </author>
+    <title level="a">
+     Авторские исправления «Войны и мира»
+    </title>
+    <title level="m">
+     Летописи Государственного Литературного музея
+    </title>
+    <biblScope>
+     Кн. 12
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1948
+     </date>
+    </imprint>
+   </item>
+   <item n="104" xml:id="Gusev_Nikolaj_Nikolaevich_Dva_goda_s_L_N_Tolstym_1928">
+    <title type="main">
+     Гусев Н. Н. Два года с Л. Н. Толстым. М.
+    </title>
+    <title type="bibl">
+     Гусев Н. Н. Два года с Л. Н. Толстым. М.: Изд. Толстовского музея, 1928.
+    </title>
+    <author>
+     Гусев Николай Николаевич
+    </author>
+    <title level="a">
+     Два года с Л. Н. Толстым
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="105" xml:id="Gusev_Nikolaj_Nikolaevich_K_istorii_Krejtserovoj_sonaty_1937">
+    <title type="main">
+     Гусев Н. Н. К истории «Крейцеровой сонаты».
+    </title>
+    <title type="bibl">
+     Гусев Н. Н. К истории «Крейцеровой сонаты» // Сборник Государственного Толстовского музея. М., 1937.
+    </title>
+    <author>
+     Гусев Николай Николаевич
+    </author>
+    <title level="a">
+     К истории «Крейцеровой сонаты»
+    </title>
+    <title level="m">
+     Сборник Государственного Толстовского музея
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1937
+     </date>
+    </imprint>
+   </item>
+   <item n="106" xml:id="Gusev_Nikolaj_Nikolaevich_Lev_Nikolaevich_Tolstoj_Materialy_k_biografii_s_1828_po_1855_god_1954">
+    <title type="main">
+     Гусев Н. Н. Лев Николаевич Толстой. Материалы к биографии с 1828 по 1855 год.
+    </title>
+    <title type="bibl">
+     Гусев Н. Н. Лев Николаевич Толстой. Материалы к биографии с 1828 по 1855 год. М.: Изд-во АН СССР, 1954.
+    </title>
+    <author>
+     Гусев Николай Николаевич
+    </author>
+    <title level="a">
+     Лев Николаевич Толстой. Материалы к биографии с 1828 по 1855 год
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд-во АН СССР
+     </publisher>
+     <date>
+      1954
+     </date>
+    </imprint>
+   </item>
+   <item n="107" xml:id="Gusev_Nikolaj_Nikolaevich_Lev_Nikolaevich_Tolstoj_Materialy_k_biografii_s_1855_po_1869_god_1957">
+    <title type="main">
+     Гусев Н. Н. Лев Николаевич Толстой. Материалы к биографии с 1855 по 1869 год.
+    </title>
+    <title type="bibl">
+     Гусев Н. Н. Лев Николаевич Толстой. Материалы к биографии с 1855 по 1869 год. М.: Изд-во АН СССР, 1957.
+    </title>
+    <author>
+     Гусев Николай Николаевич
+    </author>
+    <title level="a">
+     Лев Николаевич Толстой. Материалы к биографии с 1855 по 1869 год
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд-во АН СССР
+     </publisher>
+     <date>
+      1957
+     </date>
+    </imprint>
+   </item>
+   <item n="108" xml:id="Gusev_Nikolaj_Nikolaevich_Lev_Tolstoj_i_muzyka_1953">
+    <title type="main">
+     Гусев Н. Н. Лев Толстой и музыка.
+    </title>
+    <title type="bibl">
+     Гусев Н. Н. Лев Толстой и музыка. М.: Музгиз, 1953.
+    </title>
+    <author>
+     Гусев Николай Николаевич
+    </author>
+    <title level="a">
+     Лев Толстой и музыка
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Музгиз
+     </publisher>
+     <date>
+      1953
+     </date>
+    </imprint>
+   </item>
+   <item n="109" xml:id="Gusev_Nikolaj_Nikolaevich_Tolstoj_v_rastsvete_hudozhestvennogo_genija_1927">
+    <title type="main">
+     Гусев Н. Н. Толстой в расцвете художественного гения.
+    </title>
+    <title type="bibl">
+     Гусев Н. Н. Толстой в расцвете художественного гения. М.: Изд. Толстовского музея, 1927.
+    </title>
+    <author>
+     Гусев Николай Николаевич
+    </author>
+    <title level="a">
+     Толстой в расцвете художественного гения
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. Толстовского музея
+     </publisher>
+     <date>
+      1927
+     </date>
+    </imprint>
+   </item>
+   <item n="110" xml:id="Davydov_N_V_Iz_proshlogo_1914">
+    <title type="main">
+     Давыдов Н. В. Из прошлого.
+    </title>
+    <title type="bibl">
+     Давыдов Н. В. Из прошлого. М., 1914.
+    </title>
+    <author>
+     Давыдов Н. В.
+    </author>
+    <title level="a">
+     Из прошлого
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1914
+     </date>
+    </imprint>
+   </item>
+   <item n="111" xml:id="Danilevskij_Grigorij_Petrovich_Poezdka_v_Jasnuju_Poljanu_1886">
+    <title type="main">
+     Данилевский Г. П. Поездка в Ясную Поляну.
+    </title>
+    <title type="bibl">
+     Данилевский Г. П. Поездка в Ясную Поляну // Исторический вестник. 1886. № 3.
+    </title>
+    <author>
+     Данилевский Григорий Петрович
+    </author>
+    <title level="a">
+     Поездка в Ясную Поляну
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="112" xml:id="Delo_1862_goda_1_j_ekspeditsii_230_III_otdelenija_sobstvennoj_ego_imperatorskogo_velichestva_kantseljarii_o_gr_Lve_Tolstom_1906">
+    <title type="main">
+     Дело 1862 года 1-й экспедиции № 230) III отделения собственной его императорского величества канцелярии о гр. Льве Толстом.
+    </title>
+    <title type="bibl">
+     Дело (1862 года 1-й экспедиции № 230) III отделения собственной его императорского величества канцелярии о гр. Льве Толстом. СПб.: Изд. «Всемирного вестника», 1906.
+    </title>
+    <title level="a">
+     Дело (1862 года 1-й экспедиции № 230) III отделения собственной его императорского величества канцелярии о гр. Льве Толстом
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <publisher>
+      Изд. «Всемирного вестника»
+     </publisher>
+     <date>
+      1906
+     </date>
+    </imprint>
+   </item>
+   <item n="113" xml:id="Delo_Glavnogo_upravlenija_po_delam_tsenzury_1861_g_158_1861">
+    <title type="main">
+     Дело Главного управления по делам цензуры 1861 г. № 158.
+    </title>
+    <title type="bibl">
+     Дело Главного управления по делам цензуры 1861 г. № 158 (Центрархив).
+    </title>
+    <title level="a">
+     Дело Главного управления по делам цензуры 1861 г. № 158
+    </title>
+    <biblScope>
+     № 158
+    </biblScope>
+    <repository>
+     Центрархив
+    </repository>
+    <imprint>
+     <date>
+      1861
+     </date>
+    </imprint>
+   </item>
+   <item n="114" xml:id="Delo_gr_L_N_Tolstogo_1903">
+    <title type="main">
+     Дело гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Дело гр. Л. Н. Толстого // Яблочков М. Т. Дворянское сословие Тульской губернии. Т. 5. Ч. 1. Тула, 1903.
+    </title>
+    <title level="a">
+     Дело гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Яблочков М. Т. Дворянское сословие Тульской губернии
+    </title>
+    <biblScope>
+     Т. 5, Ч. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Тула
+     </pubPlace>
+     <date>
+      1903
+     </date>
+    </imprint>
+   </item>
+   <item n="115" xml:id="Delo_gr_Tolstyh">
+    <title type="main">
+     Дело гр. Толстых.
+    </title>
+    <title type="bibl">
+     Дело гр. Толстых (Тульский областной архив).
+    </title>
+    <title level="a">
+     Дело гр. Толстых
+    </title>
+    <repository>
+     Тульский областной архив
+    </repository>
+   </item>
+   <item n="116" xml:id="Delo_Kazanskogo_universiteta_o_prinjatii_uchenika_gr_Lva_Nikolaevicha_Tolstogo_v_chislo_slushatelej_Kazanskogo_universiteta_s_16_ijunja_1844_po_17_marta_1852">
+    <title type="main">
+     Дело Казанского университета о принятии ученика гр. Льва Николаевича Толстого в число слушателей Казанского университета, с 16 июня 1844 по 17 марта 1852.
+    </title>
+    <title type="bibl">
+     Дело Казанского университета о принятии ученика гр. Льва Николаевича Толстого в число слушателей Казанского университета, с 16 июня 1844 по 17 марта 1852 (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <title level="a">
+     Дело Казанского университета о принятии ученика гр. Льва Николаевича Толстого в число слушателей Казанского университета, с 16 июня 1844 по 17 марта 1852
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="117" xml:id="Delo_Kazanskogo_universiteta_109_o_prinjatii_v_universitet_studenta_Lva_Nikolaevicha_Tolstogo_s_28_sentjabrja_1844_14_aprelja_1847">
+    <title type="main">
+     Дело Казанского университета, № 109 о принятии в университет студента Льва Николаевича Толстого, с 28 сентября 1844 — 14 апреля 1847.
+    </title>
+    <title type="bibl">
+     Дело Казанского университета, № 109 о принятии в университет студента Льва Николаевича Толстого, с 28 сентября 1844 — 14 апреля 1847 (Архив Казанского университета)
+    </title>
+    <title level="a">
+     Дело Казанского университета, № 109 о принятии в университет студента Льва Николаевича Толстого, с 28 сентября 1844 — 14 апреля 1847
+    </title>
+    <biblScope>
+     № 109
+    </biblScope>
+    <repository>
+     Архив Казанского университета
+    </repository>
+   </item>
+   <item n="118" xml:id="Delo_osobennoj_kantseljarii_ministra_narodnogo_prosveschenija_po_predstavleniju_Moskovskogo_tsenzurnogo_komiteta_po_state_gr_Tolstogo_pod_zaglaviem_Vospitanie_i_obrazovanie">
+    <title type="main">
+     Дело особенной канцелярии министра народного просвещения по представлению Московского цензурного комитета по статье гр. Толстого под заглавием «Воспитание и образование».
+    </title>
+    <title type="bibl">
+     Дело особенной канцелярии министра народного просвещения по представлению Московского цензурного комитета по статье гр. Толстого под заглавием «Воспитание и образование» (Центрархив).
+    </title>
+    <title level="a">
+     Дело особенной канцелярии министра народного просвещения по представлению Московского цензурного комитета по статье гр. Толстого под заглавием «Воспитание и образование»
+    </title>
+    <repository>
+     Центрархив
+    </repository>
+   </item>
+   <item n="119" xml:id="Delo_po_kantseljarii_g_rektora_65_o_peremeschenii_svoekoshtnyh_studentov_vostochnoj_slovesnosti_gr_Lva_Tolstogo_i_obschej_slovesnosti_Nikolaja_Fedorchukova_pervogo_v_fakultet_juridicheskij_v_1_kurs_i_poslednego_po_razrjadu_juridicheskih_nauk_tozhe_v_1_kurs">
+    <title type="main">
+     Дело по канцелярии г. ректора № 65 о перемещении своекоштных студентов восточной словесности гр. Льва Толстого и общей словесности Николая Федорчукова: первого в факультет юридический в 1 курс и последнего по разряду юридических наук тоже в 1 курс.
+    </title>
+    <title type="bibl">
+     Дело по канцелярии г. ректора № 65 о перемещении своекоштных студентов восточной словесности гр. Льва Толстого и общей словесности Николая Федорчукова: первого в факультет юридический в 1 курс и последнего по разряду юридических наук тоже в 1 курс (Архив Казанского университета).
+    </title>
+    <title level="a">
+     Дело по канцелярии г. ректора № 65 о перемещении своекоштных студентов восточной словесности гр. Льва Толстого и общей словесности Николая Федорчукова: первого в факультет юридический в 1 курс и последнего по разряду юридических наук тоже в 1 курс
+    </title>
+    <biblScope>
+     № 65
+    </biblScope>
+    <repository>
+     Архив Казанского университета
+    </repository>
+   </item>
+   <item n="120" xml:id="Delo_1209_Tulskogo_notarialnogo_okruzhnogo_suda">
+    <title type="main">
+     Дело № 1209 Тульского нотариального окружного суда.
+    </title>
+    <title type="bibl">
+     Дело № 1209 Тульского нотариального окружного суда (Тульский областной архив).
+    </title>
+    <title level="a">
+     Дело № 1209 Тульского нотариального окружного суда
+    </title>
+    <biblScope>
+     № 1209
+    </biblScope>
+    <repository>
+     Тульский областной архив
+    </repository>
+   </item>
+   <item n="121" xml:id="Delo_34_a_1306_kantseljarii_samarskogo_gubernatora_3_stola_ob_otstavnom_poruchike_gr_Lve_Tolstom_1883_g">
+    <title type="main">
+     Дело № 34 a) 1306 канцелярии самарского губернатора 3 стола об отставном поручике гр. Льве Толстом 1883 г.
+    </title>
+    <title type="bibl">
+     Дело № 34(a) 1306 канцелярии самарского губернатора 3 стола об отставном поручике гр. Льве Толстом 1883 г. (Государственный музей Л. Н. Толстого в Москве, копия)
+    </title>
+    <title level="a">
+     Дело № 34(a) 1306 канцелярии самарского губернатора 3 стола об отставном поручике гр. Льве Толстом 1883 г.
+    </title>
+    <biblScope>
+     № 34(a) 1306
+    </biblScope>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="122" xml:id="Delo_37_Samarskogo_gubernskogo_zhandarmskogo_upravlenija_ob_uchrezhdenii_neglasnogo_nadzora_politsii_za_gr_L_N_Tolstym_1883_g">
+    <title type="main">
+     Дело № 37 Самарского губернского жандармского управления об учреждении негласного надзора полиции за гр. Л. Н. Толстым 1883 г.
+    </title>
+    <title type="bibl">
+     Дело № 37 Самарского губернского жандармского управления об учреждении негласного надзора полиции за гр. Л. Н. Толстым 1883 г. (Государственный музей Л. Н. Толстого в Москве, копия)
+    </title>
+    <title level="a">
+     Дело № 37 Самарского губернского жандармского управления об учреждении негласного надзора полиции за гр. Л. Н. Толстым 1883 г.
+    </title>
+    <biblScope>
+     № 37
+    </biblScope>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="123" xml:id="Dmitriev_Mamonov_E_A_Slavjanofily_Istoriko_kriticheskij_ocherk_1873">
+    <title type="main">
+     Дмитриев-Мамонов Э. А. Славянофилы. Историко-критический очерк.
+    </title>
+    <title type="bibl">
+     Дмитриев-Мамонов Э. А. Славянофилы. Историко-критический очерк // Русский архив. 1873. № 12.
+    </title>
+    <author>
+     Дмитриев-Мамонов Э. А.
+    </author>
+    <title level="a">
+     Славянофилы. Историко-критический очерк
+    </title>
+    <title level="m">
+     Русский архив
+    </title>
+    <biblScope>
+     № 12
+    </biblScope>
+    <imprint>
+     <date>
+      1873
+     </date>
+    </imprint>
+   </item>
+   <item n="124" xml:id="Dobrotvor_N_Ob_ottse_L_N_Tolstogo_1926">
+    <title type="main">
+     Добротвор Н. Об отце Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Добротвор Н. Об отце Л. Н. Толстого // Тульский край. 1926. № 3.
+    </title>
+    <author>
+     Добротвор Н.
+    </author>
+    <title level="a">
+     Об отце Л. Н. Толстого
+    </title>
+    <title level="m">
+     Тульский край
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1926
+     </date>
+    </imprint>
+   </item>
+   <item n="125" xml:id="Dolgorukov_P_Rossijskaja_rodoslovnaja_kniga_1855">
+    <title type="main">
+     Долгоруков П. Российская родословная книга. Ч. 2.
+    </title>
+    <title type="bibl">
+     Долгоруков П. Российская родословная книга. Ч. 2. СПб., 1855.
+    </title>
+    <author>
+     Долгоруков П.
+    </author>
+    <title level="a">
+     Российская родословная книга
+    </title>
+    <biblScope>
+     Ч. 2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1855
+     </date>
+    </imprint>
+   </item>
+   <item n="126" xml:id="Dostoevskij_Fedor_Mihajlovich_Pisma_k_zhene_1866_1880_1926">
+    <title type="main">
+     Достоевский Ф. М. Письма к жене. (1866–1880).
+    </title>
+    <title type="bibl">
+     Достоевский Ф. М. Письма к жене. (1866–1880). М.–Л., 1926.
+    </title>
+    <author>
+     Достоевский Федор Михайлович
+    </author>
+    <title level="a">
+     Письма к жене (1866–1880)
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <date>
+      1926
+     </date>
+    </imprint>
+   </item>
+   <item n="127" xml:id="Dostoevskij_Fedor_Mihajlovich_Polnoe_sobranie_sochinenij_1895">
+    <title type="main">
+     Достоевский Ф. М. Полное собрание сочинений. Т. 9.
+    </title>
+    <title type="bibl">
+     Достоевский Ф. М. Полное собрание сочинений. Т. 9. СПб., 1895.
+    </title>
+    <author>
+     Достоевский Федор Михайлович
+    </author>
+    <title level="a">
+     Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 9
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1895
+     </date>
+    </imprint>
+   </item>
+   <item n="128" xml:id="Druzhinin_Aleksandr_Vasilevich_Dnevnik">
+    <title type="main">
+     Дружинин А. В. Дневник.
+    </title>
+    <title type="bibl">
+     Дружинин А. В. Дневник (Центральный государственный архив литературы и искусства в Москве).
+    </title>
+    <author>
+     Дружинин Александр Васильевич
+    </author>
+    <title level="a">
+     Дневник
+    </title>
+    <repository>
+     Центральный государственный архив литературы и искусства
+    </repository>
+   </item>
+   <item n="129" xml:id="Druzhinin_Aleksandr_Vasilevich_Kritika_gogolevskogo_perioda_russkoj_literatury_i_nashi_k_nej_otnoshenija_1856">
+    <title type="main">
+     Дружинин А. В. Критика гоголевского периода русской литературы и наши к ней отношения.
+    </title>
+    <title type="bibl">
+     Дружинин А. В. Критика гоголевского периода русской литературы и наши к ней отношения // Библиотека для чтения. 1856. № 12.
+    </title>
+    <author>
+     Дружинин Александр Васильевич
+    </author>
+    <title level="a">
+     Критика гоголевского периода русской литературы и наши к ней отношения
+    </title>
+    <title level="m">
+     Библиотека для чтения
+    </title>
+    <biblScope>
+     № 12
+    </biblScope>
+    <imprint>
+     <date>
+      1856
+     </date>
+    </imprint>
+   </item>
+   <item n="130" xml:id="Durylin_S_N_Vs_M_Garshin_1935">
+    <title type="main">
+     Дурылин С. Н. Вс. М. Гаршин.
+    </title>
+    <title type="bibl">
+     Дурылин С. Н. Вс. М. Гаршин // Звенья. Кн. 5. М., 1935.
+    </title>
+    <author>
+     Дурылин С. Н.
+    </author>
+    <title level="a">
+     Вс. М. Гаршин
+    </title>
+    <title level="m">
+     Звенья
+    </title>
+    <biblScope>
+     Кн. 5
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1935
+     </date>
+    </imprint>
+   </item>
+   <item n="131" xml:id="Edinenie_1916">
+    <title type="main">
+     Единение. 1916. №№ 1–4.
+    </title>
+    <title type="bibl">
+     Единение. 1916. №№ 1–4.
+    </title>
+    <title level="a">
+     Единение
+    </title>
+    <biblScope>
+     №№ 1–4
+    </biblScope>
+    <imprint>
+     <date>
+      1916
+     </date>
+    </imprint>
+   </item>
+   <item n="132" xml:id="Elpatevskij_S_Ja_Literaturnye_vospominanija_1916">
+    <title type="main">
+     Елпатьевский С. Я. Литературные воспоминания.
+    </title>
+    <title type="bibl">
+     Елпатьевский С. Я. Литературные воспоминания, М.: Изд. т-ва писателей, 1916.
+    </title>
+    <author>
+     Елпатьевский С. Я.
+    </author>
+    <title level="a">
+     Литературные воспоминания
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. т-ва писателей
+     </publisher>
+     <date>
+      1916
+     </date>
+    </imprint>
+   </item>
+   <item n="133" xml:id="Ergolskaja_Tatjana_Aleksandrovna_Zapisnaja_knizhka">
+    <title type="main">
+     Ергольская Т. А. Записная книжка.
+    </title>
+    <title type="bibl">
+     Ергольская Т. А. Записная книжка (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Ергольская Татьяна Александровна
+    </author>
+    <title level="a">
+     Записная книжка
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="134" xml:id="Ergolskaja_Tatjana_Aleksandrovna_Prihodo_rashodnaja_kniga">
+    <title type="main">
+     Ергольская Т. А. Приходо-расходная книга.
+    </title>
+    <title type="bibl">
+     Ергольская Т. А. Приходо-расходная книга (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Ергольская Татьяна Александровна
+    </author>
+    <title level="a">
+     Приходо-расходная книга
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="135" xml:id="Zhdanov_V_A_Iz_istorii_sozdanija_romana_Anna_Karenina_1955">
+    <title type="main">
+     Жданов В. А. Из истории создания романа «Анна Каренина».
+    </title>
+    <title type="bibl">
+     Жданов В. А. Из истории создания романа «Анна Каренина» // Яснополянский сборник. Год 1955. Тула, 1955.
+    </title>
+    <author>
+     Жданов В. А.
+    </author>
+    <title level="a">
+     Из истории создания романа «Анна Каренина»
+    </title>
+    <title level="m">
+     Яснополянский сборник
+    </title>
+    <imprint>
+     <pubPlace>
+      Тула
+     </pubPlace>
+     <date>
+      1955
+     </date>
+    </imprint>
+   </item>
+   <item n="136" xml:id="Zhdanov_V_A_Tvorcheskaja_istorija_Anny_Kareninoj_1957">
+    <title type="main">
+     Жданов В. А. Творческая история «Анны Карениной».
+    </title>
+    <title type="bibl">
+     Жданов В. А. Творческая история «Анны Карениной». М.: «Сов. писатель», 1957.
+    </title>
+    <author>
+     Жданов В. А.
+    </author>
+    <title level="a">
+     Творческая история «Анны Карениной»
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      «Сов. писатель»
+     </publisher>
+     <date>
+      1957
+     </date>
+    </imprint>
+   </item>
+   <item n="137" xml:id="Zhdanov_V_A_Zajdenshnur_E_E_Serebrovskaja_E_S_Opisanie_rukopisej_hudozhestvennyh_proizvedenij_L_N_Tolstogo_1955">
+    <title type="main">
+     Жданов В. А., Зайденшнур Э. Е., Серебровская Е. С. Описание рукописей художественных произведений Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Жданов В. А., Зайденшнур Э. Е., Серебровская Е. С. Описание рукописей художественных произведений Л. Н. Толстого. М.: Изд-во АН СССР, 1955.
+    </title>
+    <author>
+     Жданов В. А., Зайденшнур Э. Е., Серебровская Е. С.
+    </author>
+    <title level="a">
+     Описание рукописей художественных произведений Л. Н. Толстого
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд-во АН СССР
+     </publisher>
+     <date>
+      1955
+     </date>
+    </imprint>
+   </item>
+   <item n="138" xml:id="Zhizn_dlja_vseh_1912">
+    <title type="main">
+     Жизнь для всех. 1912. № 1.
+    </title>
+    <title type="bibl">
+     Жизнь для всех. 1912. № 1.
+    </title>
+    <title level="a">
+     Жизнь для всех
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="139" xml:id="Zhirkevich_A_V_Dnevnik_1939">
+    <title type="main">
+     Жиркевич А. В. Дневник.
+    </title>
+    <title type="bibl">
+     Жиркевич А. В. Дневник // Литературное наследство. № 37–38. М., 1939.
+    </title>
+    <author>
+     Жиркевич А. В.
+    </author>
+    <title level="a">
+     Дневник
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     № 37–38
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1939
+     </date>
+    </imprint>
+   </item>
+   <item n="140" xml:id="Zhukov_I_Razbor_izvestij_o_kazni_kupecheskogo_syna_Vereschagina_1866">
+    <title type="main">
+     Жуков И. Разбор известий о казни купеческого сына Верещагина.
+    </title>
+    <title type="bibl">
+     Жуков И. Разбор известий о казни купеческого сына Верещагина // Чтения в Императорском Обществе истории и древностей российских при Московском университете. Кн. 4. 1866.
+    </title>
+    <author>
+     Жуков И.
+    </author>
+    <title level="a">
+     Разбор известий о казни купеческого сына Верещагина
+    </title>
+    <title level="m">
+     Чтения в Императорском Обществе истории и древностей российских при Московском университете
+    </title>
+    <biblScope>
+     Кн. 4
+    </biblScope>
+    <imprint>
+     <date>
+      1866
+     </date>
+    </imprint>
+   </item>
+   <item n="141" xml:id="Zhurnal_Ministerstva_narodnogo_prosveschenija_1861">
+    <title type="main">
+     Журнал Министерства народного просвещения. 1861. № 12.
+    </title>
+    <title type="bibl">
+     Журнал Министерства народного просвещения. 1861. № 12.
+    </title>
+    <title level="a">
+     Журнал Министерства народного просвещения
+    </title>
+    <biblScope>
+     № 12
+    </biblScope>
+    <imprint>
+     <date>
+      1861
+     </date>
+    </imprint>
+   </item>
+   <item n="142" xml:id="Zhurnal_osobogo_otdela_Uchenogo_Komiteta_Ministerstva_narodnogo_prosveschenija_1875">
+    <title type="main">
+     Журнал особого отдела Ученого Комитета Министерства народного просвещения. 1875. № 224 от 30 июня.
+    </title>
+    <title type="bibl">
+     Журнал особого отдела Ученого Комитета Министерства народного просвещения. 1875. № 224 от 30 июня.
+    </title>
+    <title level="a">
+     Журнал особого отдела Ученого Комитета Министерства народного просвещения
+    </title>
+    <biblScope>
+     № 224 от 30 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1875
+     </date>
+    </imprint>
+   </item>
+   <item n="143" xml:id="Zhurnaly_HIII_ocherednogo_Krapivenskogo_uezdnogo_zemskogo_sobranija_1877">
+    <title type="main">
+     Журналы ХIII очередного Крапивенского уездного земского собрания.
+    </title>
+    <title type="bibl">
+     Журналы ХIII очередного Крапивенского уездного земского собрания. Тула, 1877.
+    </title>
+    <title level="a">
+     Журналы ХIII очередного Крапивенского уездного земского собрания
+    </title>
+    <imprint>
+     <pubPlace>
+      Тула
+     </pubPlace>
+     <date>
+      1877
+     </date>
+    </imprint>
+   </item>
+   <item n="144" xml:id="Zhurnaly_XIV_ocherednogo_Krapivenskogo_uezda_zemskogo_sobranija_1878">
+    <title type="main">
+     Журналы XIV очередного Крапивенского уезда земского собрания.
+    </title>
+    <title type="bibl">
+     Журналы XIV очередного Крапивенского уезда земского собрания. Тула, 1878.
+    </title>
+    <title level="a">
+     Журналы XIV очередного Крапивенского уезда земского собрания
+    </title>
+    <imprint>
+     <pubPlace>
+      Тула
+     </pubPlace>
+     <date>
+      1878
+     </date>
+    </imprint>
+   </item>
+   <item n="145" xml:id="Zagoskin_Nikolaj_Pavlovich_Gr_L_N_Tolstoj_i_ego_studencheskie_gody_1894">
+    <title type="main">
+     Загоскин Н. П. Гр. Л. Н. Толстой и его студенческие годы.
+    </title>
+    <title type="bibl">
+     Загоскин Н. П. Гр. Л. Н. Толстой и его студенческие годы // Исторический вестник. 1894. № 1.
+    </title>
+    <author>
+     Загоскин Николай Павлович
+    </author>
+    <title level="a">
+     Гр. Л. Н. Толстой и его студенческие годы
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1894
+     </date>
+    </imprint>
+   </item>
+   <item n="146" xml:id="Zaljubovskij_A_P_Vospominanija_nedavnego_proshlogo">
+    <title type="main">
+     Залюбовский А. П. Воспоминания недавнего прошлого.
+    </title>
+    <title type="bibl">
+     Залюбовский А. П. Воспоминания недавнего прошлого (Архив В. Г. Черткова).
+    </title>
+    <author>
+     Залюбовский А. П.
+    </author>
+    <title level="a">
+     Воспоминания недавнего прошлого
+    </title>
+    <repository>
+     Архив В. Г. Черткова
+    </repository>
+   </item>
+   <item n="147" xml:id="Zapiski_istoriko_filologicheskogo_fakulteta_Sankt_Peterburgskogo_universiteta_1877">
+    <title type="main">
+     Записки историко-филологического факультета Санкт-Петербургского университета. Ч. 2. 1877.
+    </title>
+    <title type="bibl">
+     Записки историко-филологического факультета Санкт-Петербургского университета. Ч. 2. 1877.
+    </title>
+    <title level="a">
+     Записки историко-филологического факультета Санкт-Петербургского университета
+    </title>
+    <biblScope>
+     Ч. 2
+    </biblScope>
+    <imprint>
+     <date>
+      1877
+     </date>
+    </imprint>
+   </item>
+   <item n="148" xml:id="Zapiski_otdela_rukopisej_Vsesojuznoj_biblioteki_im_V_I_Lenina_1939">
+    <title type="main">
+     Записки отдела рукописей Всесоюзной библиотеки им. В. И. Ленина. Вып. 4.
+    </title>
+    <title type="bibl">
+     Записки отдела рукописей Всесоюзной библиотеки им. В. И. Ленина. Вып. 4. М., 1939.
+    </title>
+    <title level="a">
+     Записки отдела рукописей Всесоюзной библиотеки им. В. И. Ленина
+    </title>
+    <biblScope>
+     Вып. 4
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1939
+     </date>
+    </imprint>
+   </item>
+   <item n="149" xml:id="Zvenja_1932">
+    <title type="main">
+     Звенья. Кн. 1.
+    </title>
+    <title type="bibl">
+     Звенья. Кн. 1. М.–Л.: Academia, 1932.
+    </title>
+    <title level="a">
+     Звенья
+    </title>
+    <biblScope>
+     Кн. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Academia
+     </publisher>
+     <date>
+      1932
+     </date>
+    </imprint>
+   </item>
+   <item n="150" xml:id="Zelinskij_V_Russkaja_kriticheskaja_literatura_o_proizvedenijah_Tolstogo_1888">
+    <title type="main">
+     Зелинский В. Русская критическая литература о произведениях Толстого. Ч. 7.
+    </title>
+    <title type="bibl">
+     Зелинский В. Русская критическая литература о произведениях Толстого. Ч. 7. М. 1888.
+    </title>
+    <author>
+     Зелинский В.
+    </author>
+    <title level="a">
+     Русская критическая литература о произведениях Толстого
+    </title>
+    <biblScope>
+     Ч. 7
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1888
+     </date>
+    </imprint>
+   </item>
+   <item n="151" xml:id="Zjabrev_A_T_Vospominanija_o_Tolstom_1915">
+    <title type="main">
+     Зябрев А. Т. Воспоминания о Толстом
+    </title>
+    <title type="bibl">
+     Зябрев А. Т. Воспоминания о Толстом // Ежемесячный журнал. 1915. № 9–10.
+    </title>
+    <author>
+     Зябрев А. Т.
+    </author>
+    <title level="a">
+     Воспоминания о Толстом
+    </title>
+    <title level="m">
+     Ежемесячный журнал
+    </title>
+    <biblScope>
+     № 9–10
+    </biblScope>
+    <imprint>
+     <date>
+      1915
+     </date>
+    </imprint>
+   </item>
+   <item n="152" xml:id="I_S_Aksakov_v_ego_pismah_1892">
+    <title type="main">
+     И. С. Аксаков в его письмах. Т. 3.
+    </title>
+    <title type="bibl">
+     И. С. Аксаков в его письмах. Т. 3. М., 1892.
+    </title>
+    <title level="a">
+     И. С. Аксаков в его письмах
+    </title>
+    <biblScope>
+     Т. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1892
+     </date>
+    </imprint>
+   </item>
+   <item n="153" xml:id="Ivakin_I_M_Vospominanija_1885">
+    <title type="main">
+     Ивакин И. М. Воспоминания.
+    </title>
+    <title type="bibl">
+     Ивакин И. М. Воспоминания. 1885 (Центральный государственный архив литературы и искусства в Москве).
+    </title>
+    <author>
+     Ивакин И. М.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <repository>
+     Центральный государственный архив литературы и искусства
+    </repository>
+    <imprint>
+     <date>
+      1885
+     </date>
+    </imprint>
+   </item>
+   <item n="154" xml:id="Ivanov_A_A_ego_zhizn_i_perepiska_1806_1856_1880">
+    <title type="main">
+     Иванов А. А., его жизнь и переписка. 1806–1856.
+    </title>
+    <title type="bibl">
+     Иванов А. А., его жизнь и переписка. 1806–1856. СПб., 1880.
+    </title>
+    <title level="a">
+     Иванов А. А., его жизнь и переписка. 1806–1856
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1880
+     </date>
+    </imprint>
+   </item>
+   <item n="155" xml:id="Ivanov_A_Pismo_k_Tolstomu_L_N_1901">
+    <title type="main">
+     Иванов А. Письмо к Толстому Л. Н.
+    </title>
+    <title type="bibl">
+     Иванов А. Письмо к Толстому Л. Н. // Тульские епархиальные ведомости. 1901. № 7–8.
+    </title>
+    <author>
+     Иванов А.
+    </author>
+    <title level="a">
+     Письмо к Толстому Л. Н.
+    </title>
+    <title level="m">
+     Тульские епархиальные ведомости
+    </title>
+    <biblScope>
+     № 7–8
+    </biblScope>
+    <imprint>
+     <date>
+      1901
+     </date>
+    </imprint>
+   </item>
+   <item n="156" xml:id="Ivanov_N_N_U_L_N_Tolstogo_v_1886_godu_1929">
+    <title type="main">
+     Иванов Н. Н. У Л. Н. Толстого в 1886 году.
+    </title>
+    <title type="bibl">
+     Иванов Н. Н. У Л. Н. Толстого в 1886 году // Толстой Л. Н. Юбилейный сборник. М.–Л., 1929.
+    </title>
+    <author>
+     Иванов Н. Н.
+    </author>
+    <title level="a">
+     У Л. Н. Толстого в 1886 году
+    </title>
+    <title level="m">
+     Толстой Л. Н. Юбилейный сборник
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="157" xml:id="Izvestija_ob_va_Tolstovskogo_muzeja_Vyp_3_5_1911">
+    <title type="main">
+     Известия об-ва Толстовского музея, Вып. 3–5.
+    </title>
+    <title type="bibl">
+     Известия об-ва Толстовского музея, Вып. 3–5. М., 1911.
+    </title>
+    <title level="a">
+     Известия об-ва Толстовского музея, Вып. 3–5
+    </title>
+    <biblScope>
+     Вып. 3–5
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="158" xml:id="Ilinskij_I_Zhandarmskij_obysk_v_Jasnoj_Poljane_1932">
+    <title type="main">
+     Ильинский И. Жандармский обыск в Ясной Поляне.
+    </title>
+    <title type="bibl">
+     Ильинский И. Жандармский обыск в Ясной Поляне // Звенья. кн. 1. 1932.
+    </title>
+    <author>
+     Ильинский И.
+    </author>
+    <title level="a">
+     Жандармский обыск в Ясной Поляне
+    </title>
+    <title level="m">
+     Звенья
+    </title>
+    <biblScope>
+     Кн. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      M.
+     </pubPlace>
+     <date>
+      1932
+     </date>
+    </imprint>
+   </item>
+   <item n="159" xml:id="Istomin_V_K_Vospominanija">
+    <title type="main">
+     Истомин В. К. Воспоминания.
+    </title>
+    <title type="bibl">
+     Истомин В. К. Воспоминания (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Истомин В. К.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="160" xml:id="Istoricheskij_arhiv_1956">
+    <title type="main">
+     Исторический архив. 1956. № 1.
+    </title>
+    <title type="bibl">
+     Исторический архив. 1956. № 1.
+    </title>
+    <title level="m">
+     Исторический архив
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1956
+     </date>
+    </imprint>
+   </item>
+   <item n="161" xml:id="Istoricheskij_vestnik_1884">
+    <title type="main">
+     Исторический вестник. 1884. № 11.
+    </title>
+    <title type="bibl">
+     Исторический вестник. 1884. № 11.
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1884
+     </date>
+    </imprint>
+   </item>
+   <item n="162" xml:id="K_biografii_L_N_Tolstogo_1911">
+    <title type="main">
+     К биографии Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     К биографии Л. Н. Толстого // Русская мысль. 1911. № 4.
+    </title>
+    <title level="a">
+     К биографии Л. Н. Толстого
+    </title>
+    <title level="m">
+     Русская мысль
+    </title>
+    <biblScope>
+     № 4
+    </biblScope>
+    <imprint>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="163" xml:id="Kazanskie_gubernskie_vedomosti_1845">
+    <title type="main">
+     Казанские губернские ведомости. 1845. № 11.
+    </title>
+    <title type="bibl">
+     Казанские губернские ведомости. 1845. № 11.
+    </title>
+    <title level="a">
+     Казанские губернские ведомости
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1845
+     </date>
+    </imprint>
+   </item>
+   <item n="164" xml:id="Kazanskie_gubernskie_vedomosti_1846">
+    <title type="main">
+     Казанские губернские ведомости. 1846. № 18.
+    </title>
+    <title type="bibl">
+     Казанские губернские ведомости. 1846. № 18.
+    </title>
+    <title level="a">
+     Казанские губернские ведомости
+    </title>
+    <biblScope>
+     № 18
+    </biblScope>
+    <imprint>
+     <date>
+      1846
+     </date>
+    </imprint>
+   </item>
+   <item n="165" xml:id="Karjakin_V_N_Moskovskaja_ohranka_o_L_N_Tolstom_i_tolstovtsah_1918">
+    <title type="main">
+     Карякин В. Н. Московская охранка о Л. Н. Толстом и толстовцах.
+    </title>
+    <title type="bibl">
+     Карякин В. Н. Московская охранка о Л. Н. Толстом и толстовцах // Голос минувшего. 1918. №№ 4–6.
+    </title>
+    <author>
+     Карякин В. Н.
+    </author>
+    <title level="a">
+     Московская охранка о Л. Н. Толстом и толстовцах
+    </title>
+    <title level="m">
+     Голос минувшего
+    </title>
+    <biblScope>
+     №№ 4–6
+    </biblScope>
+    <imprint>
+     <date>
+      1918
+     </date>
+    </imprint>
+   </item>
+   <item n="166" xml:id="Katkov_Mihail_Nikiforovich_Pisma_1939">
+    <title type="main">
+     Катков М. Н. Письма.
+    </title>
+    <title type="bibl">
+     Катков М. Н. Письма. // Литературное наследство. № 37–38. М., 1939.
+    </title>
+    <author>
+     Катков Михаил Никифорович
+    </author>
+    <title level="a">
+     Письма
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     № 37–38
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1939
+     </date>
+    </imprint>
+   </item>
+   <item n="167" xml:id="Kashkin_N_N_Rodoslovnye_razvedki_1913">
+    <title type="main">
+     Кашкин Н. Н. Родословные разведки. Т. 2. СПб., 1913.
+    </title>
+    <title type="bibl">
+     Кашкин Н. Н. Родословные разведки. Т. 2. СПб., 1913.
+    </title>
+    <author>
+     Кашкин Н. Н.
+    </author>
+    <title level="a">
+     Родословные разведки
+    </title>
+    <biblScope>
+     Т. 2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="168" xml:id="Kalsiev_V_I_Ispoved_1941">
+    <title type="main">
+     Кельсиев В. И. Исповедь.
+    </title>
+    <title type="bibl">
+     Кельсиев В. И. Исповедь // Литературное наследство. № 41–42. М., 1941.
+    </title>
+    <author>
+     Кальсиев В. И.
+    </author>
+    <title level="a">
+     Исповедь
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     № 41–42
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1941
+     </date>
+    </imprint>
+   </item>
+   <item n="169" xml:id="Kokorev_V_A_Vzgljad_russkogo_na_evropejskuju_torgovlju_1858">
+    <title type="main">
+     Кокорев В. А. Взгляд русского на европейскую торговлю.
+    </title>
+    <title type="bibl">
+     Кокорев В. А. Взгляд русского на европейскую торговлю // Русский вестник. 1858. Март.
+    </title>
+    <author>
+     Кокорев В. А.
+    </author>
+    <title level="a">
+     Взгляд русского на европейскую торговлю
+    </title>
+    <title level="m">
+     Русский вестник
+    </title>
+    <imprint>
+     <pubPlace>
+      M.
+     </pubPlace>
+     <date>
+      1858
+     </date>
+    </imprint>
+   </item>
+   <item n="170" xml:id="Koni_Anatolij_Fedorovich_Na_zhiznennom_puti_1916">
+    <title type="main">
+     Кони А. Ф. На жизненном пути. Т. 2.
+    </title>
+    <title type="bibl">
+     Кони А. Ф. На жизненном пути. Т. 2. М., 1916.
+    </title>
+    <author>
+     Кони Анатолий Федорович
+    </author>
+    <title level="a">
+     На жизненном пути
+    </title>
+    <biblScope>
+     Т. 2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1916
+     </date>
+    </imprint>
+   </item>
+   <item n="171" xml:id="Kornilov_A_Gody_stranstvij_Mih_Bakunina_1915">
+    <title type="main">
+     Корнилов А. Годы странствий Мих. Бакунина.
+    </title>
+    <title type="bibl">
+     Корнилов А. Годы странствий Мих. Бакунина, М., 1915.
+    </title>
+    <author>
+     Корнилов А.
+    </author>
+    <title level="a">
+     Годы странствий Мих. Бакунина
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1915
+     </date>
+    </imprint>
+   </item>
+   <item n="172" xml:id="Korolenko_Vladimir_Galaktionovich_Pismo_k_Korolenko_Ju_G_1923">
+    <title type="main">
+     Короленко В. Г. Письмо к Короленко Ю. Г.
+    </title>
+    <title type="bibl">
+     Короленко В. Г. Письмо к Короленко Ю. Г. // Короленко В. Г. Полное посмертное собрание сочинений. Т. 1. Киев, 1923.
+    </title>
+    <author>
+     Короленко Владимир Галактионович
+    </author>
+    <title level="a">
+     Письмо к Короленко Ю. Г.
+    </title>
+    <title level="m">
+     Короленко В. Г. Полное посмертное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Киев
+     </pubPlace>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="173" xml:id="Kramskoj_Ivan_Nikolaevich_Pisma_1937">
+    <title type="main">
+     Крамской И. Н. Письма. Т. 1.
+    </title>
+    <title type="bibl">
+     Крамской И. Н. Письма. Т. 1. М.: «Искусство», 1937.
+    </title>
+    <author>
+     Крамской Иван Николаевич
+    </author>
+    <title level="a">
+     Письма
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      «Искусство»
+     </publisher>
+     <date>
+      1937
+     </date>
+    </imprint>
+   </item>
+   <item n="174" xml:id="Krasnyj_arhiv_1927">
+    <title type="main">
+     Красный архив. 1927. № 3.
+    </title>
+    <title type="bibl">
+     Красный архив. 1927. № 3.
+    </title>
+    <title level="a">
+     Красный архив
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1927
+     </date>
+    </imprint>
+   </item>
+   <item n="175" xml:id="Krepostnaja_Tulskogo_notarialnogo_arhiva_kniga_po_Krapivenskomu_uezdu_za_1891_g">
+    <title type="main">
+     Крепостная Тульского нотариального архива книга по Крапивенскому уезду за 1891 г.
+    </title>
+    <title type="bibl">
+     Крепостная Тульского нотариального архива книга по Крапивенскому уезду за 1891 г. (Тульский областной архив).
+    </title>
+    <title level="a">
+     Крепостная Тульского нотариального архива книга по Крапивенскому уезду за 1891 г.
+    </title>
+    <repository>
+     Тульский областной архив
+    </repository>
+   </item>
+   <item n="176" xml:id="Krivenko_S_N_Literaturnye_vospominanija_1890">
+    <title type="main">
+     Кривенко С. Н. Литературные воспоминания.
+    </title>
+    <title type="bibl">
+     Кривенко С. Н. Литературные воспоминания // Исторический вестник. 1890. № 2.
+    </title>
+    <author>
+     Кривенко С. Н.
+    </author>
+    <title level="a">
+     Литературные воспоминания
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 2
+    </biblScope>
+    <imprint>
+     <date>
+      1890
+     </date>
+    </imprint>
+   </item>
+   <item n="177" xml:id="Ksjunin_A_Uhod_Tolstogo_1911">
+    <title type="main">
+     Ксюнин А. Уход Толстого.
+    </title>
+    <title type="bibl">
+     Ксюнин А. Уход Толстого. СПб., 1911.
+    </title>
+    <author>
+     Ксюнин А.
+    </author>
+    <title level="a">
+     Уход Толстого
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="178" xml:id="Kuzminskaja_Tatjana_Andreevna_Moja_zhizn_doma_i_v_Jasnoj_Poljane_Vospominanija_1846_1862_1925_izd_2_e_1927">
+    <title type="main">
+     Кузминская Т. А. (рожд. Берс). Моя жизнь дома и в Ясной Поляне. Воспоминания. 1846–1862.
+    </title>
+    <title type="bibl">
+     Кузминская Т. А. (рожд. Берс). Моя жизнь дома и в Ясной Поляне. Воспоминания. 1846–1862. / Предисловие и примечания М. А. Цявловского. М.: Изд. М. и С. Сабашниковых, 1925; изд. 2-е. — 1927.
+    </title>
+    <author>
+     Кузминская Татьяна Андреевна
+    </author>
+    <title level="a">
+     Моя жизнь дома и в Ясной Поляне. Воспоминания. 1846–1862
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. М. и С. Сабашниковых
+     </publisher>
+     <date>
+      1925; изд. 2-е. — 1927
+     </date>
+    </imprint>
+   </item>
+   <item n="179" xml:id="Kuzminskaja_Tatjana_Andreevna_Moja_zhizn_doma_i_v_Jasnoj_Poljane_Vospominanija_1863_1864_1926_izd_2_e_1927">
+    <title type="main">
+     Кузминская Т. А. (рожд. Берс). Моя жизнь дома и в Ясной Поляне. Воспоминания. 1863–1864.
+    </title>
+    <title type="bibl">
+     Кузминская Т. А. (рожд. Берс). Моя жизнь дома и в Ясной Поляне. Воспоминания. 1863–1864. / Предисловие и примечания М. А. Цявловского. М.: Изд. М. и С. Сабашниковых, 1926; изд. 2-е — 1927.
+    </title>
+    <author>
+     Кузминская Татьяна Андреевна
+    </author>
+    <title level="a">
+     Моя жизнь дома и в Ясной Поляне. Воспоминания. 1863–1864
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. М. и С. Сабашниковых
+     </publisher>
+     <date>
+      1926; изд. 2-е — 1927
+     </date>
+    </imprint>
+   </item>
+   <item n="180" xml:id="Kuzminskaja_Tatjana_Andreevna_Moja_zhizn_doma_i_v_Jasnoj_Poljane_Vospominanija_1864_1868_1926_izd_2_e_1928">
+    <title type="main">
+     Кузминская Т. А. (рожд. Берс). Моя жизнь дома и в Ясной Поляне. Воспоминания. 1864–1868.
+    </title>
+    <title type="bibl">
+     Кузминская Т. А. (рожд. Берс). Моя жизнь дома и в Ясной Поляне. Воспоминания. 1864–1868. / Предисловие и примечания М. А. Цявловского. М.: Изд. М. и С. Сабашниковых, 1926; изд. 2-е. — 1928.
+    </title>
+    <author>
+     Кузминская Татьяна Андреевна
+    </author>
+    <title level="a">
+     Моя жизнь дома и в Ясной Поляне. Воспоминания. 1864–1868
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. М. и С. Сабашниковых
+     </publisher>
+     <date>
+      1926; изд. 2-е. — 1928
+     </date>
+    </imprint>
+   </item>
+   <item n="181" xml:id="Lavrov_P_L_Izbrannye_sochinenija_na_sots_politicheskie_temy_1934">
+    <title type="main">
+     Лавров П. Л. Избранные сочинения на соц.-политические темы. Т. 3.
+    </title>
+    <title type="bibl">
+     Лавров П. Л. Избранные сочинения на соц.-политические темы. Т. 3. М., 1934.
+    </title>
+    <author>
+     Лавров П. Л.
+    </author>
+    <title level="a">
+     Избранные сочинения на соц.-политические темы.
+    </title>
+    <biblScope>
+     Т. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1934
+     </date>
+    </imprint>
+   </item>
+   <item n="182" xml:id="Lavrov_P_L_Po_povodu_samarskogo_goloda_1873">
+    <title type="main">
+     Лавров П. Л. По поводу самарского голода.
+    </title>
+    <title type="bibl">
+     Лавров П. Л. По поводу самарского голода // Вперед. Женева, 1873. № 2.
+    </title>
+    <author>
+     Лавров П. Л.
+    </author>
+    <title level="a">
+     По поводу самарского голода
+    </title>
+    <title level="m">
+     Вперед
+    </title>
+    <biblScope>
+     № 2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Женевa
+     </pubPlace>
+     <date>
+      1873
+     </date>
+    </imprint>
+   </item>
+   <item n="183" xml:id="Lazurskij_V_F_Dnevnik_1939">
+    <title type="main">
+     Лазурский В. Ф. Дневник.
+    </title>
+    <title type="bibl">
+     Лазурский В. Ф. Дневник //Литературное наследство. № 37–38. М., 1939.
+    </title>
+    <author>
+     Лазурский В. Ф.
+    </author>
+    <title level="a">
+     Дневник
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     № 37–38
+    </biblScope>
+    <imprint>
+     <date>
+      1939
+     </date>
+    </imprint>
+   </item>
+   <item n="184" xml:id="Laskin_E_Razbor_i_izvlechenie_iz_romana_Vojna_i_mir_1870">
+    <title type="main">
+     Ласкин Е. Разбор и извлечение из романа «Война и мир».
+    </title>
+    <title type="bibl">
+     Ласкин Е. Разбор и извлечение из романа «Война и мир». М., 1870.
+    </title>
+    <author>
+     Ласкин Е.
+    </author>
+    <title level="a">
+     Разбор и извлечение из романа «Война и мир»
+    </title>
+    <imprint>
+     <date>
+      1870
+     </date>
+    </imprint>
+   </item>
+   <item n="185" xml:id="Tolstoj_Lev_Nikolaevich_Stasov_Vladimir_Vasilevich_Perepiska_1876_1906_1929">
+    <title type="main">
+     Лев Толстой и В. В. Стасов. Переписка. 1876–1906.
+    </title>
+    <title type="bibl">
+     Лев Толстой и В. В. Стасов. Переписка. 1876–1906. Л.: «Прибой», 1929.
+    </title>
+    <author>
+     Толстой Лев Николаевич, Стасов Владимир Васильевич
+    </author>
+    <title level="a">
+     Переписка. 1876–1906
+    </title>
+    <imprint>
+     <pubPlace>
+      Л.
+     </pubPlace>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="186" xml:id="Levenfeld_R_B_Gr_L_N_Tolstoj_v_suzhdenijah_o_nem_ego_blizkih_i_v_razgovorah_s_nim_samim_1897">
+    <title type="main">
+     Левенфельд Р. Б. Гр. Л. Н. Толстой в суждениях о нем его близких и в разговорах с ним самим.
+    </title>
+    <title type="bibl">
+     Левенфельд Р. Б. Гр. Л. Н. Толстой в суждениях о нем его близких и в разговорах с ним самим // Русское обозрение. 1897. № 10.
+    </title>
+    <author>
+     Левенфельд Р. Б.
+    </author>
+    <title level="a">
+     Гр. Л. Н. Толстой в суждениях о нем его близких и в разговорах с ним самим
+    </title>
+    <title level="m">
+     Русское обозрение
+    </title>
+    <biblScope>
+     № 10
+    </biblScope>
+    <imprint>
+     <date>
+      1897
+     </date>
+    </imprint>
+   </item>
+   <item n="187" xml:id="Levenfeld_R_B_Drama_Tolstogo_na_nemetskoj_stsene_1908">
+    <title type="main">
+     Левенфельд Р. Б. Драма Толстого на немецкой сцене.
+    </title>
+    <title type="bibl">
+     Левенфельд Р. Б. Драма Толстого на немецкой сцене // Театр и искусство. 1908. № 34.
+    </title>
+    <author>
+     Левенфельд Р. Б.
+    </author>
+    <title level="a">
+     Драма Толстого на немецкой сцене
+    </title>
+    <title level="m">
+     Театр и искусство
+    </title>
+    <biblScope>
+     № 34
+    </biblScope>
+    <imprint>
+     <date>
+      1908
+     </date>
+    </imprint>
+   </item>
+   <item n="188" xml:id="Levenfeld_R_B_Graf_L_N_Tolstoj_ego_zhizn_proizvedenija_i_mirosozertsanie_1896">
+    <title type="main">
+     Левенфельд Р. Граф Л. Н. Толстой, его жизнь, произведения и миросозерцание.
+    </title>
+    <title type="bibl">
+     Левенфельд Р. Граф Л. Н. Толстой, его жизнь, произведения и миросозерцание. СПб., 1896.
+    </title>
+    <author>
+     Левенфельд Р. Б.
+    </author>
+    <title level="a">
+     Граф Л. Н. Толстой, его жизнь, произведения и миросозерцание
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1896
+     </date>
+    </imprint>
+   </item>
+   <item n="189" xml:id="Lerner_N_Iz_zhizni_L_N_Tolstogo_1910">
+    <title type="main">
+     Лернер Н. Из жизни Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Лернер Н. Из жизни Л. Н. Толстого // Биржевые ведомости. 1910. 7 ноября.
+    </title>
+    <author>
+     Лернер Н.
+    </author>
+    <title level="a">
+     Из жизни Л. Н. Толстого
+    </title>
+    <title level="m">
+     Биржевые ведомости
+    </title>
+    <imprint>
+     <date>
+      1910
+     </date>
+    </imprint>
+   </item>
+   <item n="190" xml:id="Leskov_A_N_Zhizn_Nikolaja_Leskova_1954">
+    <title type="main">
+     Лесков А. Н. Жизнь Николая Лескова.
+    </title>
+    <title type="bibl">
+     Лесков А. Н. Жизнь Николая Лескова. М.: Гослитиздат, 1954.
+    </title>
+    <author>
+     Лесков А. Н.
+    </author>
+    <title level="a">
+     Жизнь Николая Лескова
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1954
+     </date>
+    </imprint>
+   </item>
+   <item n="191" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869">
+    <title type="main">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
+    </title>
+    <title type="bibl">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому // Биржевые ведомости. 1869. № 109.
+    </title>
+    <author>
+     Лесков Николай Семенович
+    </author>
+    <title level="a">
+     Герои Отечественной войны по гр. Л. Н. Толстому
+    </title>
+    <title level="m">
+     Биржевые ведомости
+    </title>
+    <biblScope>
+     № 109
+    </biblScope>
+    <imprint>
+     <date>
+      1869
+     </date>
+    </imprint>
+   </item>
+   <item n="192" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_b">
+    <title type="main">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
+    </title>
+    <title type="bibl">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому // Биржевые ведомости. 1869. № 68.
+    </title>
+    <author>
+     Лесков Николай Семенович
+    </author>
+    <title level="a">
+     Герои Отечественной войны по гр. Л. Н. Толстому
+    </title>
+    <title level="m">
+     Биржевые ведомости
+    </title>
+    <biblScope>
+     № 68
+    </biblScope>
+    <imprint>
+     <date>
+      1869
+     </date>
+    </imprint>
+   </item>
+   <item n="193" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_c">
+    <title type="main">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
+    </title>
+    <title type="bibl">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому // Биржевые ведомости. 1869. № 70.
+    </title>
+    <author>
+     Лесков Николай Семенович
+    </author>
+    <title level="a">
+     Герои Отечественной войны по гр. Л. Н. Толстому
+    </title>
+    <title level="m">
+     Биржевые ведомости
+    </title>
+    <biblScope>
+     № 70
+    </biblScope>
+    <imprint>
+     <date>
+      1869
+     </date>
+    </imprint>
+   </item>
+   <item n="194" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_d">
+    <title type="main">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
+    </title>
+    <title type="bibl">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому // Биржевые ведомости. 1869. № 75.
+    </title>
+    <author>
+     Лесков Николай Семенович
+    </author>
+    <title level="a">
+     Герои Отечественной войны по гр. Л. Н. Толстому
+    </title>
+    <title level="m">
+     Биржевые ведомости
+    </title>
+    <biblScope>
+     № 75
+    </biblScope>
+    <imprint>
+     <date>
+      1869
+     </date>
+    </imprint>
+   </item>
+   <item n="195" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_e">
+    <title type="main">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
+    </title>
+    <title type="bibl">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому // Биржевые ведомости. 1869. № 98.
+    </title>
+    <author>
+     Лесков Николай Семенович
+    </author>
+    <title level="a">
+     Герои Отечественной войны по гр. Л. Н. Толстому
+    </title>
+    <title level="m">
+     Биржевые ведомости
+    </title>
+    <biblScope>
+     № 98
+    </biblScope>
+    <imprint>
+     <date>
+      1869
+     </date>
+    </imprint>
+   </item>
+   <item n="196" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_f">
+    <title type="main">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
+    </title>
+    <title type="bibl">
+     Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому // Биржевые ведомости. 1869. № 99.
+    </title>
+    <author>
+     Лесков Николай Семенович
+    </author>
+    <title level="a">
+     Герои Отечественной войны по гр. Л. Н. Толстому
+    </title>
+    <title level="m">
+     Биржевые ведомости
+    </title>
+    <biblScope>
+     № 99
+    </biblScope>
+    <imprint>
+     <date>
+      1869
+     </date>
+    </imprint>
+   </item>
+   <item n="197" xml:id="L_N_Tolstoj_1948">
+    <title type="main">
+     Летописи Гос. Литературного Музея. Кн. 12. Л. Н. Толстой. Т. 2.
+    </title>
+    <title type="bibl">
+     Летописи Государственного Литературного Музея. Кн. 12. Л. Н. Толстой. Т. 2. М., 1948.
+    </title>
+    <title level="a">
+     Л. Н. Толстой
+    </title>
+    <title level="m">
+     Летописи Государственного Литературного Музея
+    </title>
+    <biblScope>
+     Кн. 12, Т. 2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1948
+     </date>
+    </imprint>
+   </item>
+   <item n="198" xml:id="Pisma_k_A_V_Druzhininu_1948">
+    <title type="main">
+     Летописи Гос. Литературного Музея. Кн. 9. Письма к А. В. Дружинину.
+    </title>
+    <title type="bibl">
+     Летописи Государственного Литературного Музея. Кн. 9. Письма к А. В. Дружинину. М., 1948.
+    </title>
+    <title level="a">
+     Письма к А. В. Дружинину
+    </title>
+    <title level="m">
+     Летописи Государственного Литературного Музея
+    </title>
+    <biblScope>
+     Кн. 9
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1948
+     </date>
+    </imprint>
+   </item>
+   <item n="199" xml:id="Literaturnaja_gazeta_1931">
+    <title type="main">
+     Литературная газета. 1931. № 13 от 9 марта.
+    </title>
+    <title type="bibl">
+     Литературная газета. 1931. № 13 от 9 марта.
+    </title>
+    <title level="m">
+     Литературная газета
+    </title>
+    <biblScope>
+     № 13 от 9 марта
+    </biblScope>
+    <imprint>
+     <date>
+      1931
+     </date>
+    </imprint>
+   </item>
+   <item n="200" xml:id="Literaturnoe_nasledstvo_1934">
+    <title type="main">
+     Литературное наследство. 1934. № 15.
+    </title>
+    <title type="bibl">
+     Литературное наследство. 1934. № 15.
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     № 15
+    </biblScope>
+    <imprint>
+     <date>
+      1934
+     </date>
+    </imprint>
+   </item>
+   <item n="201" xml:id="Literaturnoe_nasledstvo_1935">
+    <title type="main">
+     Литературное наследство. 1935. №№ 22–24.
+    </title>
+    <title type="bibl">
+     Литературное наследство. 1935. №№ 22–24.
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     №№ 22–24
+    </biblScope>
+    <imprint>
+     <date>
+      1935
+     </date>
+    </imprint>
+   </item>
+   <item n="202" xml:id="Literaturnoe_nasledstvo_1936">
+    <title type="main">
+     Литературное наследство. 1936. №№ 25–26.
+    </title>
+    <title type="bibl">
+     Литературное наследство. 1936. №№ 25–26.
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     №№ 25–26
+    </biblScope>
+    <imprint>
+     <date>
+      1936
+     </date>
+    </imprint>
+   </item>
+   <item n="203" xml:id="Literaturnoe_nasledstvo_1937">
+    <title type="main">
+     Литературное наследство. 1937. №№ 31–32.
+    </title>
+    <title type="bibl">
+     Литературное наследство. 1937. №№ 31–32.
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     №№ 31–32
+    </biblScope>
+    <imprint>
+     <date>
+      1937
+     </date>
+    </imprint>
+   </item>
+   <item n="204" xml:id="Literaturnoe_nasledstvo_1939">
+    <title type="main">
+     Литературное наследство. 1939. №№ 37–38.
+    </title>
+    <title type="bibl">
+     Литературное наследство. 1939. №№ 37–38.
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     №№ 37–38
+    </biblScope>
+    <imprint>
+     <date>
+      1939
+     </date>
+    </imprint>
+   </item>
+   <item n="205" xml:id="Literaturnoe_nasledstvo_1941">
+    <title type="main">
+     Литературное наследство. 1941. №№ 41–42.
+    </title>
+    <title type="bibl">
+     Литературное наследство. 1941. №№ 41–42.
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     №№ 41–42
+    </biblScope>
+    <imprint>
+     <date>
+      1941
+     </date>
+    </imprint>
+   </item>
+   <item n="206" xml:id="Literaturnoe_nasledstvo_1949">
+    <title type="main">
+     Литературное наследство. 1949. №№ 53–54.
+    </title>
+    <title type="bibl">
+     Литературное наследство. 1949. №№ 53–54.
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     №№ 53–54
+    </biblScope>
+    <imprint>
+     <date>
+      1949
+     </date>
+    </imprint>
+   </item>
+   <item n="207" xml:id="Literaturnoe_nasledstvo_1953">
+    <title type="main">
+     Литературное наследство. 1953. № 61.
+    </title>
+    <title type="bibl">
+     Литературное наследство. 1953. № 61.
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     № 61
+    </biblScope>
+    <imprint>
+     <date>
+      1953
+     </date>
+    </imprint>
+   </item>
+   <item n="208" xml:id="Literaturnoe_nasledstvo_1955">
+    <title type="main">
+     Литературное наследство. 1955. № 62.
+    </title>
+    <title type="bibl">
+     Литературное наследство. 1955. № 62.
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     № 62
+    </biblScope>
+    <imprint>
+     <date>
+      1955
+     </date>
+    </imprint>
+   </item>
+   <item n="209" xml:id="Literaturnyj_obozrenie_1872">
+    <title type="main">
+     Литературное обозрение.
+    </title>
+    <title type="bibl">
+     Литературное обозрение // Всемирная иллюстрация. 1872. № 181 от 17 июня.
+    </title>
+    <title level="a">
+     Литературный обозрение
+    </title>
+    <title level="m">
+     Всемирная иллюстрация
+    </title>
+    <biblScope>
+     № 181 от 17 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1872
+     </date>
+    </imprint>
+   </item>
+   <item n="210" xml:id="Literaturnye_novosti_1867">
+    <title type="main">
+     Литературные новости.
+    </title>
+    <title type="bibl">
+     Литературные новости // Восток. 1867. № 1.
+    </title>
+    <title level="a">
+     Литературные новости
+    </title>
+    <title level="m">
+     Восток
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1867
+     </date>
+    </imprint>
+   </item>
+   <item n="211" xml:id="Literaturnyj_arhiv_1953">
+    <title type="main">
+     Литературный архив. 4.
+    </title>
+    <title type="bibl">
+     Литературный архив. 4. М.–Л.: Изд-во АН СССР, 1953.
+    </title>
+    <title level="a">
+     Литературный архив
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Изд-во АН СССР
+     </publisher>
+     <date>
+      1953
+     </date>
+    </imprint>
+   </item>
+   <item n="212" xml:id="Lomunov_K_N_Dramaturgija_L_N_Tolstogo_1956">
+    <title type="main">
+     Ломунов К. Н. Драматургия Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Ломунов К. Н. Драматургия Л. Н. Толстого. М.: «Искусство», 1956.
+    </title>
+    <author>
+     Ломунов К. Н.
+    </author>
+    <title level="a">
+     Драматургия Л. Н. Толстого
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      «Искусство»
+     </publisher>
+     <date>
+      1956
+     </date>
+    </imprint>
+   </item>
+   <item n="213" xml:id="Lopatin_V_M_Iz_teatralnyh_vospominanij_1909">
+    <title type="main">
+     Лопатин В. М. Из театральных воспоминаний.
+    </title>
+    <title type="bibl">
+     Лопатин В. М. Из театральных воспоминаний // Международный толстовский альманах, составленный П. А. Сергеенко. М., 1909.
+    </title>
+    <author>
+     Лопатин В. М.
+    </author>
+    <title level="a">
+     Из театральных воспоминаний
+    </title>
+    <title level="m">
+     Международный толстовский альманах, составленный П. А. Сергеенко
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="214" xml:id="Lystsev_N_Vospominanija_1909">
+    <title type="main">
+     Лысцев Н. Воспоминания.
+    </title>
+    <title type="bibl">
+     Лысцев Н. Воспоминания // Русские ведомости. 1909. № 20.
+    </title>
+    <author>
+     Лысцев Н.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Русские ведомости
+    </title>
+    <biblScope>
+     № 20
+    </biblScope>
+    <imprint>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="215" xml:id="Ljubich_E_N_Zapiski">
+    <title type="main">
+     Любич Е. Н. Записки.
+    </title>
+    <title type="bibl">
+     Любич Е. Н. Записки (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Любич Е. Н.
+    </author>
+    <title level="a">
+     Записки
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="216" xml:id="Majkov_L_N_A_S_Pushkin_Biograficheskie_i_istoriko_literaturnye_stati_1899">
+    <title type="main">
+     Майков Л. Н. А. С. Пушкин. Биографические и историко-литературные статьи.
+    </title>
+    <title type="bibl">
+     Майков Л. Н. А. С. Пушкин. Биографические и историко-литературные статьи. СПб., 1899.
+    </title>
+    <author>
+     Майков Л. Н.
+    </author>
+    <title level="a">
+     А. С. Пушкин. Биографические и историко-литературные статьи
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1899
+     </date>
+    </imprint>
+   </item>
+   <item n="217" xml:id="Makovitskij_Dushan_Petrovich_Jasnopoljanskie_zapiski_1905_1910">
+    <title type="main">
+     Маковицкий Д. П. Яснополянские записки. 1905–1910.
+    </title>
+    <title type="bibl">
+     Маковицкий Д. П. Яснополянские записки. 1905–1910 (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Маковицкий Душан Петрович
+    </author>
+    <title level="a">
+     Яснополянские записки. 1905–1910
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="218" xml:id="Makovitskij_Dushan_Petrovich_Jasnopoljanskie_zapiski_1922">
+    <title type="main">
+     Маковицкий Д. П. Яснополянские записки. Вып. 1.
+    </title>
+    <title type="bibl">
+     Маковицкий Д. П. Яснополянские записки. Вып. 1. М.: Изд. «Задруга», 1922.
+    </title>
+    <author>
+     Маковицкий Душан Петрович
+    </author>
+    <title level="a">
+     Яснополянские записки
+    </title>
+    <biblScope>
+     Вып. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. «Задруга»
+     </publisher>
+     <date>
+      1922
+     </date>
+    </imprint>
+   </item>
+   <item n="219" xml:id="Markov_E_L_Zhivaja_dusha_v_shkole_1900">
+    <title type="main">
+     Марков Е. Л. Живая душа в школе.
+    </title>
+    <title type="bibl">
+     Марков Е. Л. Живая душа в школе // Вестник Европы. 1900. № 2.
+    </title>
+    <author>
+     Марков Е. Л.
+    </author>
+    <title level="a">
+     Живая душа в школе
+    </title>
+    <title level="m">
+     Вестник Европы
+    </title>
+    <biblScope>
+     № 2
+    </biblScope>
+    <imprint>
+     <date>
+      1900
+     </date>
+    </imprint>
+   </item>
+   <item n="220" xml:id="Menkov_P_K_Zapiski_1898">
+    <title type="main">
+     Меньков П. К. Записки. Т. 1.
+    </title>
+    <title type="bibl">
+     Меньков П. К. Записки. Т. 1. СПб., 1898.
+    </title>
+    <author>
+     Меньков П. К.
+    </author>
+    <title level="a">
+     Записки
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1898
+     </date>
+    </imprint>
+   </item>
+   <item n="221" xml:id="Miller_F_I_Izvestija_o_dvorjanah_rossijskih_1790">
+    <title type="main">
+     Миллер Ф. И. Известия о дворянах российских.
+    </title>
+    <title type="bibl">
+     Миллер Ф. И. Известия о дворянах российских. СПб., 1790.
+    </title>
+    <author>
+     Миллер Ф. И.
+    </author>
+    <title level="a">
+     Известия о дворянах российских
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1790
+     </date>
+    </imprint>
+   </item>
+   <item n="222" xml:id="Miloshevich_N_S_Iz_zapisok_sevastopoltsa_1904">
+    <title type="main">
+     Милошевич Н. С. Из записок севастопольца.
+    </title>
+    <title type="bibl">
+     Милошевич Н. С. Из записок севастопольца. СПб., 1904.
+    </title>
+    <author>
+     Милошевич Н. С.
+    </author>
+    <title level="a">
+     Из записок севастопольца
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1904
+     </date>
+    </imprint>
+   </item>
+   <item n="223" xml:id="Mihajlov_V_M_Lopatin_Plody_prosveschenija_v_Jasnoj_Poljane_1928">
+    <title type="main">
+     Михайлов В. М. (Лопатин). «Плоды просвещения» в Ясной Поляне.
+    </title>
+    <title type="bibl">
+     Михайлов В. М. (Лопатин). «Плоды просвещения» в Ясной Поляне // Светский театр. 1928. № 37.
+    </title>
+    <author>
+     Михайлов В. М. (Лопатин)
+    </author>
+    <title level="a">
+     «Плоды просвещения» в Ясной Поляне
+    </title>
+    <title level="m">
+     Светский театр
+    </title>
+    <biblScope>
+     № 37
+    </biblScope>
+    <imprint>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="224" xml:id="Mihajlovskij_N_K_Literaturnye_vospominanija_i_sovremennaja_smuta_1900">
+    <title type="main">
+     Михайловский Н. К. Литературные воспоминания и современная смута. Т. 1.
+    </title>
+    <title type="bibl">
+     Михайловский Н. К. Литературные воспоминания и современная смута. Т. 1. СПб., 1900.
+    </title>
+    <author>
+     Михайловский Н. К.
+    </author>
+    <title level="a">
+     Литературные воспоминания и современная смута
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1900
+     </date>
+    </imprint>
+   </item>
+   <item n="225" xml:id="Modzalevskij_B_L_Rod_gr_L_N_Tolstogo_1917">
+    <title type="main">
+     Модзалевский Б. Л. Род гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Модзалевский Б. Л. Род гр. Л. Н. Толстого // Толстой. Памятники творчества и жизни. Т. 1. Пд., 1917.
+    </title>
+    <author>
+     Модзалевский Б. Л.
+    </author>
+    <title level="a">
+     Род гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Толстой. Памятники творчества и жизни
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Пд.
+     </pubPlace>
+     <date>
+      1917
+     </date>
+    </imprint>
+   </item>
+   <item n="226" xml:id="Modzalevskij_B_L_Spisok_chlenov_imperatorskoj_Akademii_Nauk_1908">
+    <title type="main">
+     Модзалевский Б. Л. Список членов имп. Академии Наук.
+    </title>
+    <title type="bibl">
+     Модзалевский Б. Л. Список членов императорской Академии Наук. СПб., 1908.
+    </title>
+    <author>
+     Модзалевский Б. Л.
+    </author>
+    <title level="a">
+     Список членов императорской Академии Наук
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1908
+     </date>
+    </imprint>
+   </item>
+   <item n="227" xml:id="Moiseev_R_Vozmutitelnaja_vyhodka_L_N_Tolstogo_1924">
+    <title type="main">
+     Моисеев Р. Возмутительная выходка Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Моисеев Р. Возмутительная выходка Л. Н. Толстого // Красная газета. Вечерний выпуск. 1924. 20 ноября.
+    </title>
+    <author>
+     Моисеев Р.
+    </author>
+    <title level="a">
+     Возмутительная выходка Л. Н. Толстого
+    </title>
+    <title level="m">
+     Красная газета. Вечерний выпуск.
+    </title>
+    <biblScope>
+     Вечерний выпуск
+    </biblScope>
+    <imprint>
+     <date>
+      1924
+     </date>
+    </imprint>
+   </item>
+   <item n="228" xml:id="Molostvov_N_G_Sergeenko_P_A_Lev_Tolstoj_1910">
+    <title type="main">
+     Молоствов Н. Г. и Сергеенко П. А. Лев Толстой.
+    </title>
+    <title type="bibl">
+     Молоствов Н. Г. и Сергеенко П. А. Лев Толстой. СПб.: Изд. П. Сойкина, 1910.
+    </title>
+    <author>
+     Молоствов Н. Г., Сергеенко П. А.
+    </author>
+    <title level="a">
+     Лев Толстой
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <publisher>
+      Изд. П. Сойкина
+     </publisher>
+     <date>
+      1910
+     </date>
+    </imprint>
+   </item>
+   <item n="229" xml:id="Morozov_V_S_Vospominanija_o_L_N_Tolstom_uchenika_jasnopoljanskoj_shkoly_1917">
+    <title type="main">
+     Морозов В. С. Воспоминания о Л. Н. Толстом ученика яснополянской школы. / Ред. и примеч. А. Сергеенко. М.: «Посредник», 1917.
+    </title>
+    <title type="bibl">
+     Морозов В. С. Воспоминания о Л. Н. Толстом ученика яснополянской школы. / Ред. и примеч. А. Сергеенко. М.: «Посредник», 1917.
+    </title>
+    <author>
+     Морозов В. С.
+    </author>
+    <editor>
+     Сергеенко А.
+    </editor>
+    <title level="a">
+     Воспоминания о Л. Н. Толстом ученика яснополянской школы
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      «Посредник»
+     </publisher>
+     <date>
+      1917
+     </date>
+    </imprint>
+   </item>
+   <item n="230" xml:id="Morozov_P_V_Vospominanija_uchitelja_tolstovskoj_shkoly_1912">
+    <title type="main">
+     Морозов П. В. Воспоминания учителя толстовской школы.
+    </title>
+    <title type="bibl">
+     Морозов П. В. Воспоминания учителя толстовской школы // Русское слово. 1912. № 257 от 7 ноября.
+    </title>
+    <author>
+     Морозов П. В.
+    </author>
+    <title level="a">
+     Воспоминания учителя толстовской школы
+    </title>
+    <title level="m">
+     Русское слово
+    </title>
+    <biblScope>
+     № 257 от 7 ноября
+    </biblScope>
+    <imprint>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="231" xml:id="Moskovskie_vedomosti_1868">
+    <title type="main">
+     Московские ведомости. 1868. № 11 от 16 января.
+    </title>
+    <title type="bibl">
+     Московские ведомости. 1868. № 11 от 16 января.
+    </title>
+    <title level="m">
+     Московские ведомости
+    </title>
+    <biblScope>
+     № 11 от 16 января
+    </biblScope>
+    <imprint>
+     <date>
+      1868
+     </date>
+    </imprint>
+   </item>
+   <item n="232" xml:id="Moskovskie_vedomosti_1868_b">
+    <title type="main">
+     Московские ведомости. 1868. № 19 от 25 января.
+    </title>
+    <title type="bibl">
+     Московские ведомости. 1868. № 19 от 25 января.
+    </title>
+    <title level="m">
+     Московские ведомости
+    </title>
+    <biblScope>
+     № 19 от 25 января
+    </biblScope>
+    <imprint>
+     <date>
+      1868
+     </date>
+    </imprint>
+   </item>
+   <item n="233" xml:id="Moskovskie_tserkovnye_vedomosti_1886">
+    <title type="main">
+     Московские церковные ведомости. 1886. № 4.
+    </title>
+    <title type="bibl">
+     Московские церковные ведомости. 1886. № 4.
+    </title>
+    <title level="m">
+     Московские церковные ведомости
+    </title>
+    <biblScope>
+     № 4
+    </biblScope>
+    <imprint>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="234" xml:id="Moskovskij_nekropol_1908">
+    <title type="main">
+     Московский некрополь. Т. 3.
+    </title>
+    <title type="bibl">
+     Московский некрополь. Т. 3. СПб., 1908.
+    </title>
+    <title level="a">
+     Московский некрополь
+    </title>
+    <biblScope>
+     Т. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1908
+     </date>
+    </imprint>
+   </item>
+   <item n="235" xml:id="Muranovskij_sbornik_I_1908">
+    <title type="main">
+     Мурановский сборник I.
+    </title>
+    <title type="bibl">
+     Мурановский сборник I. Мураново, 1908.
+    </title>
+    <title level="a">
+     Мурановский сборник I
+    </title>
+    <imprint>
+     <pubPlace>
+      Мураново
+     </pubPlace>
+     <date>
+      1908
+     </date>
+    </imprint>
+   </item>
+   <item n="236" xml:id="N_skij_B_L_N_Tolstoj_i_departament_politsii_1918">
+    <title type="main">
+     Н-ский Б. Л. Н. Толстой и департамент полиции.
+    </title>
+    <title type="bibl">
+     Н-ский Б. Л. Н. Толстой и департамент полиции // Былое. 1918. № 9.
+    </title>
+    <author>
+     Н-ский Б.
+    </author>
+    <title level="a">
+     Л. Н. Толстой и департамент полиции
+    </title>
+    <title level="m">
+     Былое
+    </title>
+    <biblScope>
+     № 9
+    </biblScope>
+    <imprint>
+     <date>
+      1918
+     </date>
+    </imprint>
+   </item>
+   <item n="237" xml:id="Nazarev_V_N_Zhizn_i_ljudi_bylogo_vremeni_1891">
+    <title type="main">
+     Назарьев В. Н. Жизнь и люди былого времени.
+    </title>
+    <title type="bibl">
+     Назарьев В. Н. Жизнь и люди былого времени // Исторический вестник. 1891. № 11.
+    </title>
+    <author>
+     Назарьев В. Н.
+    </author>
+    <title level="a">
+     Жизнь и люди былого времени
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1891
+     </date>
+    </imprint>
+   </item>
+   <item n="238" xml:id="Neva_1956">
+    <title type="main">
+     Нева. 1956. № 9.
+    </title>
+    <title type="bibl">
+     Нева. 1956. № 9.
+    </title>
+    <title level="a">
+     Нева
+    </title>
+    <biblScope>
+     № 9
+    </biblScope>
+    <imprint>
+     <date>
+      1956
+     </date>
+    </imprint>
+   </item>
+   <item n="239" xml:id="Neizdannye_pisma_k_A_N_Ostrovskomu_1932">
+    <title type="main">
+     Неизданные письма к А. Н. Островскому.
+    </title>
+    <title type="bibl">
+     Неизданные письма к А. Н. Островскому. М.–Л.: Изд. Academia, 1932.
+    </title>
+    <title level="a">
+     Неизданные письма к А. Н. Островскому
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Изд. Academia
+     </publisher>
+     <date>
+      1932
+     </date>
+    </imprint>
+   </item>
+   <item n="240" xml:id="Nekrasov_Nikolaj_Alekseevich_Zametki_o_zhurnalah_1856">
+    <title type="main">
+     Некрасов Н. А. Заметки о журналах.
+    </title>
+    <title type="bibl">
+     Некрасов Н. А. Заметки о журналах // Современник. 1856. № 2.
+    </title>
+    <author>
+     Некрасов Николай Алексеевич
+    </author>
+    <title level="a">
+     Заметки о журналах
+    </title>
+    <title level="m">
+     Современник
+    </title>
+    <biblScope>
+     № 2
+    </biblScope>
+    <imprint>
+     <date>
+      1856
+     </date>
+    </imprint>
+   </item>
+   <item n="241" xml:id="Nekrasov_Nikolaj_Alekseevich_Zametki_o_zhurnalah_za_sentjabr_1855_g_1855">
+    <title type="main">
+     Некрасов Н. А. Заметки о журналах за сентябрь 1855 г.
+    </title>
+    <title type="bibl">
+     Некрасов Н. А. Заметки о журналах за сентябрь 1855 г. // Современник. 1855. № 10.
+    </title>
+    <author>
+     Некрасов Николай Алексеевич
+    </author>
+    <title level="a">
+     Заметки о журналах за сентябрь 1855 г.
+    </title>
+    <title level="m">
+     Современник
+    </title>
+    <biblScope>
+     № 10
+    </biblScope>
+    <imprint>
+     <date>
+      1855
+     </date>
+    </imprint>
+   </item>
+   <item n="242" xml:id="Nekrasov_Nikolaj_Alekseevich_Polnoe_sobranie_sochinenij_i_pisem_1952">
+    <title type="main">
+     Некрасов Н. А. Полное собрание сочинений и писем. Т. 10.
+    </title>
+    <title type="bibl">
+     Некрасов Н. А. Полное собрание сочинений и писем. Т. 10. М.: Гослитиздат, 1952.
+    </title>
+    <author>
+     Некрасов Николай Алексеевич
+    </author>
+    <title level="a">
+     Полное собрание сочинений и писем
+    </title>
+    <biblScope>
+     Т. 10
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Гослитиздат
+     </publisher>
+     <date>
+      1952
+     </date>
+    </imprint>
+   </item>
+   <item n="243" xml:id="Nekrasov_Nikolaj_Alekseevich_Polnoe_sobranie_sochinenij_i_pisem_1950">
+    <title type="main">
+     Некрасов Н. А. Полное собрание сочинений и писем. Т. 9.
+    </title>
+    <title type="bibl">
+     Некрасов Н. А. Полное собрание сочинений и писем. Т. 9. М.: Гослитиздат, 1950.
+    </title>
+    <author>
+     Некрасов Николай Алексеевич
+    </author>
+    <title level="a">
+     Полное собрание сочинений и писем
+    </title>
+    <biblScope>
+     Т. 9
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Гослитиздат
+     </publisher>
+     <date>
+      1950
+     </date>
+    </imprint>
+   </item>
+   <item n="244" xml:id="Nemerovskaja_O_Vokrug_Anny_Kareninoj_1928">
+    <title type="main">
+     Немеровская О. Вокруг «Анны Карениной».
+    </title>
+    <title type="bibl">
+     Немеровская О. Вокруг «Анны Карениной» // Печать и революция. 1928. № 6.
+    </title>
+    <author>
+     Немеровская О.
+    </author>
+    <title level="a">
+     Вокруг «Анны Карениной»
+    </title>
+    <title level="m">
+     Печать и революция
+    </title>
+    <biblScope>
+     № 6
+    </biblScope>
+    <imprint>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="245" xml:id="Nemirovich_Danchenko_Vladimir_Ivanovich_Iz_proshlogo_1936">
+    <title type="main">
+     Немирович-Данченко Вл. И. Из прошлого.
+    </title>
+    <title type="bibl">
+     Немирович-Данченко Вл. И. Из прошлого. М.: Academia, 1936.
+    </title>
+    <author>
+     Немирович Данченко Владимир Иванович
+    </author>
+    <title level="a">
+     Из прошлого
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1936
+     </date>
+    </imprint>
+   </item>
+   <item n="246" xml:id="Neopublikovannye_pisma_A_A_Stahovicha">
+    <title type="main">
+     Неопубликованные письма А. А. Стаховича.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма А. А. Стаховича.
+    </title>
+    <title level="a">
+     Неопубликованные письма А. А. Стаховича
+    </title>
+   </item>
+   <item n="247" xml:id="Neopublikovannye_pisma_A_A_Feta">
+    <title type="main">
+     Неопубликованные письма А. А. Фета.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма А. А. Фета.
+    </title>
+    <title level="a">
+     Неопубликованные письма А. А. Фета
+    </title>
+   </item>
+   <item n="248" xml:id="Neopublikovannye_pisma_A_G_Arhangelskoj">
+    <title type="main">
+     Неопубликованные письма А. Г. Архангельской.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма А. Г. Архангельской.
+    </title>
+    <title level="a">
+     Неопубликованные письма А. Г. Архангельской
+    </title>
+   </item>
+   <item n="249" xml:id="Neopublikovannye_pisma_A_I_Ertelja">
+    <title type="main">
+     Неопубликованные письма А. И. Эртеля.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма А. И. Эртеля (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <title level="a">
+     Неопубликованные письма А. И. Эртеля
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="250" xml:id="Neopublikovannye_pisma_A_M_Kalmykovoj">
+    <title type="main">
+     Неопубликованные письма А. М. Калмыковой.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма А. М. Калмыковой.
+    </title>
+    <title level="a">
+     Неопубликованные письма А. М. Калмыковой
+    </title>
+   </item>
+   <item n="251" xml:id="Neopublikovannye_pisma_A_M_Kuzminskogo">
+    <title type="main">
+     Неопубликованные письма А. М. Кузминского.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма А. М. Кузминского.
+    </title>
+    <title level="a">
+     Неопубликованные письма А. М. Кузминского
+    </title>
+   </item>
+   <item n="252" xml:id="Neopublikovannye_pisma_V_Andronova">
+    <title type="main">
+     Неопубликованные письма В. Андронова.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма В. Андронова.
+    </title>
+    <title level="a">
+     Неопубликованные письма В. Андронова
+    </title>
+   </item>
+   <item n="253" xml:id="Neopublikovannye_pisma_V_I_Alekseeva">
+    <title type="main">
+     Неопубликованные письма В. И. Алексеева.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма В. И. Алексеева.
+    </title>
+    <title level="a">
+     Неопубликованные письма В. И. Алексеева
+    </title>
+   </item>
+   <item n="254" xml:id="Neopublikovannye_pisma_V_P_Tolstogo">
+    <title type="main">
+     Неопубликованные письма В. П. Толстого.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма В. П. Толстого.
+    </title>
+    <title level="a">
+     Неопубликованные письма В. П. Толстого
+    </title>
+   </item>
+   <item n="255" xml:id="Neopublikovannye_pisma_G_S_Arhangelskogo">
+    <title type="main">
+     Неопубликованные письма Г. С. Архангельского.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма Г. С. Архангельского.
+    </title>
+    <title level="a">
+     Неопубликованные письма Г. С. Архангельского
+    </title>
+   </item>
+   <item n="256" xml:id="Neopublikovannye_pisma_D_I_Shahovskogo">
+    <title type="main">
+     Неопубликованные письма Д. И. Шаховского.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма Д. И. Шаховского.
+    </title>
+    <title level="a">
+     Неопубликованные письма Д. И. Шаховского
+    </title>
+   </item>
+   <item n="257" xml:id="Neopublikovannye_pisma_E_M_Feoktistova">
+    <title type="main">
+     Неопубликованные письма Е. М. Феоктистова.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма Е. М. Феоктистова.
+    </title>
+    <title level="a">
+     Неопубликованные письма Е. М. Феоктистова
+    </title>
+   </item>
+   <item n="258" xml:id="Neopublikovannye_pisma_I_E_Obolenskogo">
+    <title type="main">
+     Неопубликованные письма И. Е. Оболенского.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма И. Е. Оболенского.
+    </title>
+    <title level="a">
+     Неопубликованные письма И. Е. Оболенского
+    </title>
+   </item>
+   <item n="259" xml:id="Neopublikovannye_pisma_I_I_Rodzevicha">
+    <title type="main">
+     Неопубликованные письма И. И. Родзевича.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма И. И. Родзевича.
+    </title>
+    <title level="a">
+     Неопубликованные письма И. И. Родзевича
+    </title>
+   </item>
+   <item n="260" xml:id="Neopublikovannye_pisma_I_P_Borisova">
+    <title type="main">
+     Неопубликованные письма И. П. Борисова
+    </title>
+    <title type="bibl">
+     Неопубликованные письма И. П. Борисова (Российская государственная библиотека).
+    </title>
+    <title level="a">
+     Неопубликованные письма И. П. Борисова
+    </title>
+    <repository>
+     Российская государственная библиотека
+    </repository>
+   </item>
+   <item n="261" xml:id="Neopublikovannye_pisma_I_P_Borisova_b">
+    <title type="main">
+     Неопубликованные письма И. П. Борисова.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма И. П. Борисова.
+    </title>
+    <title level="a">
+     Неопубликованные письма И. П. Борисова.
+    </title>
+   </item>
+   <item n="262" xml:id="Neopublikovannye_pisma_I_S_Aksakova">
+    <title type="main">
+     Неопубликованные письма И. С. Аксакова.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма И. С. Аксакова.
+    </title>
+    <title level="a">
+     Неопубликованные письма И. С. Аксакова
+    </title>
+   </item>
+   <item n="263" xml:id="Neopublikovannye_pisma_K_A_Islavina">
+    <title type="main">
+     Неопубликованные письма К. А. Иславина.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма К. А. Иславина.
+    </title>
+    <title level="a">
+     Неопубликованные письма К. А. Иславина
+    </title>
+   </item>
+   <item n="264" xml:id="Neopublikovannye_pisma_M_A_Dondukova_Korsakova">
+    <title type="main">
+     Неопубликованные письма М. А. Дондукова-Корсакова..
+    </title>
+    <title type="bibl">
+     Неопубликованные письма М. А. Дондукова-Корсакова.
+    </title>
+    <title level="a">
+     Неопубликованные письма М. А. Дондукова-Корсакова
+    </title>
+   </item>
+   <item n="265" xml:id="Neopublikovannye_pisma_M_L_Tolstoj">
+    <title type="main">
+     Неопубликованные письма М. Л. Толстой.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма М. Л. Толстой.
+    </title>
+    <title level="a">
+     Неопубликованные письма М. Л. Толстой
+    </title>
+   </item>
+   <item n="266" xml:id="Neopublikovannye_pisma_M_N_Puschina">
+    <title type="main">
+     Неопубликованные письма М. Н. Пущина.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма М. Н. Пущина.
+    </title>
+    <title level="a">
+     Неопубликованные письма М. Н. Пущина
+    </title>
+   </item>
+   <item n="267" xml:id="Neopublikovannye_pisma_M_N_Tolstoj">
+    <title type="main">
+     Неопубликованные письма М. Н. Толстой.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма М. Н. Толстой.
+    </title>
+    <title level="a">
+     Неопубликованные письма М. Н. Толстой
+    </title>
+   </item>
+   <item n="268" xml:id="Neopublikovannye_pisma_N_I_Storozhenko">
+    <title type="main">
+     Неопубликованные письма Н. И. Стороженко.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма Н. И. Стороженко.
+    </title>
+    <title level="a">
+     Неопубликованные письма Н. И. Стороженко
+    </title>
+   </item>
+   <item n="269" xml:id="Neopublikovannye_pisma_N_N_Tolstogo">
+    <title type="main">
+     Неопубликованные письма Н. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма Н. Н. Толстого.
+    </title>
+    <title level="a">
+     Неопубликованные письма Н. Н. Толстого
+    </title>
+   </item>
+   <item n="270" xml:id="Neopublikovannye_pisma_N_Ja_Grota">
+    <title type="main">
+     Неопубликованные письма Н. Я. Грота.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма Н. Я. Грота.
+    </title>
+    <title level="a">
+     Неопубликованные письма Н. Я. Грота
+    </title>
+   </item>
+   <item n="271" xml:id="Neopublikovannye_pisma_P_A_Bersa">
+    <title type="main">
+     Неопубликованные письма П. А. Берса.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма П. А. Берса.
+    </title>
+    <title level="a">
+     Неопубликованные письма П. А. Берса
+    </title>
+   </item>
+   <item n="272" xml:id="Neopublikovannye_pisma_P_A_Gajdeburova">
+    <title type="main">
+     Неопубликованные письма П. А. Гайдебурова.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма П. А. Гайдебурова.
+    </title>
+    <title level="a">
+     Неопубликованные письма П. А. Гайдебурова
+    </title>
+   </item>
+   <item n="273" xml:id="Neopublikovannye_pisma_P_Bobrinskogo">
+    <title type="main">
+     Неопубликованные письма П. Бобринского.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма П. Бобринского.
+    </title>
+    <title level="a">
+     Неопубликованные письма П. Бобринского
+    </title>
+   </item>
+   <item n="274" xml:id="Neopublikovannye_pisma_P_D_Golohvastova">
+    <title type="main">
+     Неопубликованные письма П. Д. Голохвастова.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма П. Д. Голохвастова.
+    </title>
+    <title level="a">
+     Неопубликованные письма П. Д. Голохвастова
+    </title>
+   </item>
+   <item n="275" xml:id="Neopublikovannye_pisma_R_Saint_Thomas">
+    <title type="main">
+     Неопубликованные письма Р. Saint-Thomas.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма Р. Saint-Thomas.
+    </title>
+    <title level="a">
+     Неопубликованные письма Р. Saint-Thomas
+    </title>
+   </item>
+   <item n="276" xml:id="Neopublikovannye_pisma_S_A_Jureva">
+    <title type="main">
+     Неопубликованные письма С. А. Юрьева.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма С. А. Юрьева.
+    </title>
+    <title level="a">
+     Неопубликованные письма С. А. Юрьева
+    </title>
+   </item>
+   <item n="277" xml:id="Neopublikovannye_pisma_S_M_Gejdena">
+    <title type="main">
+     Неопубликованные письма С. М. Гейдена.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма С. М. Гейдена.
+    </title>
+    <title level="a">
+     Неопубликованные письма С. М. Гейдена
+    </title>
+   </item>
+   <item n="278" xml:id="Neopublikovannye_pisma_S_S_Urusova">
+    <title type="main">
+     Неопубликованные письма С. С. Урусова.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма С. С. Урусова.
+    </title>
+    <title level="a">
+     Неопубликованные письма С. С. Урусова
+    </title>
+   </item>
+   <item n="279" xml:id="Neopublikovannye_pisma_F_B_Getsa">
+    <title type="main">
+     Неопубликованные письма Ф. Б. Геца.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма Ф. Б. Геца.
+    </title>
+    <title level="a">
+     Неопубликованные письма Ф. Б. Геца
+    </title>
+   </item>
+   <item n="280" xml:id="Neopublikovannye_pisma_A_A_Potehina">
+    <title type="main">
+     Неопубликованные письма A. А. Потехина.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма A. А. Потехина.
+    </title>
+    <title level="a">
+     Неопубликованные письма A. А. Потехина
+    </title>
+   </item>
+   <item n="281" xml:id="Neopublikovannye_pisma_A_E_Bersa">
+    <title type="main">
+     Неопубликованные письма A. Е. Берса.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма A. Е. Берса.
+    </title>
+    <title level="a">
+     Неопубликованные письма A. Е. Берса
+    </title>
+   </item>
+   <item n="282" xml:id="Neopublikovannye_pisma_B_A_Islavina">
+    <title type="main">
+     Неопубликованные письма B. А. Иславина.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма B. А. Иславина.
+    </title>
+    <title level="a">
+     Неопубликованные письма B. А. Иславина
+    </title>
+   </item>
+   <item n="283" xml:id="Neopublikovannye_pisma_B_S_Serovoj">
+    <title type="main">
+     Неопубликованные письма B. С. Серовой.
+    </title>
+    <title type="bibl">
+     Неопубликованные письма B. С. Серовой.
+    </title>
+    <title level="a">
+     Неопубликованные письма B. С. Серовой
+    </title>
+   </item>
+   <item n="284" xml:id="Nikitenko_A_V_Dnevnik_1955">
+    <title type="main">
+     Никитенко А. В. Дневник. Т. 1. 1826–1857.
+    </title>
+    <title type="bibl">
+     Никитенко А. В. Дневник. Т. 1. 1826–1857. М.: Гослитиздат, 1955.
+    </title>
+    <author>
+     Никитенко А. В.
+    </author>
+    <title level="a">
+     Дневник
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1955
+     </date>
+    </imprint>
+   </item>
+   <item n="285" xml:id="Nikiforov_L_P_Vospominanija_o_L_N_Tolstom_1929">
+    <title type="main">
+     Никифоров Л. П. Воспоминания о Л. Н. Толстом.
+    </title>
+    <title type="bibl">
+     Никифоров Л. П. Воспоминания о Л. Н. Толстом // Толстой Л. Н. Юбилейный сборник. М., 1929.
+    </title>
+    <author>
+     Никифоров Л. П.
+    </author>
+    <title level="a">
+     Воспоминания о Л. Н. Толстом
+    </title>
+    <title level="m">
+     Толстой Л. Н. Юбилейный сборник
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="286" xml:id="Nikolskij_Jur_Delo_o_pohoronah_I_S_Turgeneva_1917">
+    <title type="main">
+     Никольский Юр. Дело о похоронах И. С. Тургенева.
+    </title>
+    <title type="bibl">
+     Никольский Юр. Дело о похоронах И. С. Тургенева // Былое. 1917. № 4.
+    </title>
+    <author>
+     Никольский Юр.
+    </author>
+    <title level="a">
+     Дело о похоронах И. С. Тургенева
+    </title>
+    <title level="m">
+     Былое
+    </title>
+    <biblScope>
+     № 4
+    </biblScope>
+    <imprint>
+     <date>
+      1917
+     </date>
+    </imprint>
+   </item>
+   <item n="287" xml:id="Nikon_Smert_gr_L_N_Tolstogo_1911">
+    <title type="main">
+     Никон, епископ. Смерть гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Никон, епископ. Смерть гр. Л. Н. Толстого // Троицкий листок. Тип. Троице-Сергиевской лавры, 1911.
+    </title>
+    <author>
+     Никон
+    </author>
+    <title level="a">
+     Смерть гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Троицкий листок
+    </title>
+    <imprint>
+     <publisher>
+      Тип. Троице-Сергиевской лавры
+     </publisher>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="288" xml:id="Novikov_A_M_Zima_1889_1890_gg_v_Jasnoj_Poljane_1929">
+    <title type="main">
+     Новиков А. М. Зима 1889–1890 гг. в Ясной Поляне.
+    </title>
+    <title type="bibl">
+     Новиков А. М. Зима 1889–1890 гг. в Ясной Поляне // Толстой Л. Н. Юбилейный сборник. М., 1929.
+    </title>
+    <author>
+     Новиков А. М.
+    </author>
+    <title level="a">
+     Зима 1889–1890 гг. в Ясной Поляне
+    </title>
+    <title level="m">
+     Толстой Л. Н. Юбилейный сборник
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="289" xml:id="Novitskij_A_Perov_Vasilij_Grigorevich_1902">
+    <title type="main">
+     Новицкий А. Перов Василий Григорьевич.
+    </title>
+    <title type="bibl">
+     Новицкий А. Перов Василий Григорьевич // Русский биографический словарь. Павел — Петр. СПб., 1902.
+    </title>
+    <author>
+     Новицкий А.
+    </author>
+    <title level="a">
+     Перов Василий Григорьевич
+    </title>
+    <title level="m">
+     Русский биографический словарь. Павел — Петр
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1902
+     </date>
+    </imprint>
+   </item>
+   <item n="290" xml:id="Novoe_vremja_1883">
+    <title type="main">
+     Новое время. 1883. № 2734.
+    </title>
+    <title type="bibl">
+     Новое время. 1883. № 2734.
+    </title>
+    <title level="m">
+     Новое время
+    </title>
+    <biblScope>
+     № 2734
+    </biblScope>
+    <imprint>
+     <date>
+      1883
+     </date>
+    </imprint>
+   </item>
+   <item n="291" xml:id="Novoe_vremja_1890">
+    <title type="main">
+     Новое время. 1890. № 4985.
+    </title>
+    <title type="bibl">
+     Новое время. 1890. № 4985.
+    </title>
+    <title level="m">
+     Новое время
+    </title>
+    <biblScope>
+     № 4985
+    </biblScope>
+    <imprint>
+     <date>
+      1890
+     </date>
+    </imprint>
+   </item>
+   <item n="292" xml:id="Novyj_mir_1957">
+    <title type="main">
+     Новый мир. 1957. № 9.
+    </title>
+    <title type="bibl">
+     Новый мир. 1957. № 9.
+    </title>
+    <title level="m">
+     Новый мир
+    </title>
+    <biblScope>
+     № 9
+    </biblScope>
+    <imprint>
+     <date>
+      1957
+     </date>
+    </imprint>
+   </item>
+   <item n="293" xml:id="Obolenskij_A_D_Dve_vstrechi_s_L_N_Tolstym_1923">
+    <title type="main">
+     Оболенский А. Д. Две встречи с Л. Н. Толстым.
+    </title>
+    <title type="bibl">
+     Оболенский А. Д. Две встречи с Л. Н. Толстым // Толстой. Памятники творчества и жизни. Вып. 3. М., 1923.
+    </title>
+    <author>
+     Оболенский А. Д.
+    </author>
+    <title level="a">
+     Две встречи с Л. Н. Толстым
+    </title>
+    <title level="m">
+     Толстой. Памятники творчества и жизни
+    </title>
+    <biblScope>
+     Вып. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="294" xml:id="Obolenskij_A_D_Vospominanija_Otryvki_1909">
+    <title type="main">
+     Оболенский Д. Д. Воспоминания. Отрывки.
+    </title>
+    <title type="bibl">
+     Оболенский Д. Д. Воспоминания. Отрывки // Международный толстовский альманах, составленный П. А. Сергеенко. М., 1909.
+    </title>
+    <author>
+     Оболенский А. Д.
+    </author>
+    <title level="a">
+     Воспоминания. Отрывки
+    </title>
+    <title level="m">
+     Международный толстовский альманах, составленный П. А. Сергеенко
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="295" xml:id="Obolenskij_D_D_Vpered_ili_nazad_1909">
+    <title type="main">
+     Оболенский Д. Д. Вперед или назад?
+    </title>
+    <title type="bibl">
+     Оболенский Д. Д. Вперед или назад? // Русское слово. 1909. № 194 от 25 августа.
+    </title>
+    <author>
+     Оболенский Д. Д.
+    </author>
+    <title level="a">
+     Вперед или назад?
+    </title>
+    <title level="m">
+     Русское слово
+    </title>
+    <biblScope>
+     № 194 от 25 августа
+    </biblScope>
+    <imprint>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="296" xml:id="Obolenskij_D_D_O_Vlasti_tmy_gr_L_N_Tolstogo_1908">
+    <title type="main">
+     Оболенский Д. Д. О «Власти тьмы» гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Оболенский Д. Д. О «Власти тьмы» гр. Л. Н. Толстого // Русское слово. 1908. № 212 от 13 сентября.
+    </title>
+    <author>
+     Оболенский Д. Д.
+    </author>
+    <title level="a">
+     О «Власти тьмы» гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Русское слово
+    </title>
+    <biblScope>
+     № 212 от 13 сентября
+    </biblScope>
+    <imprint>
+     <date>
+      1908
+     </date>
+    </imprint>
+   </item>
+   <item n="297" xml:id="Istoricheskaja_zapiska_i_materialy_za_sto_let_1911">
+    <title type="main">
+     Общество любителей российской словесности. Историческая записка и материалы за сто лет.
+    </title>
+    <title type="bibl">
+     Общество любителей российской словесности. Историческая записка и материалы за сто лет. М., 1911.
+    </title>
+    <title level="a">
+     Историческая записка и материалы за сто лет
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="298" xml:id="Objavlenija_1886">
+    <title type="main">
+     Объявления. — «Новости» 1886, №79 от 9 апреля.
+    </title>
+    <title type="bibl">
+     Объявления // Новости. 1886. № 79 от 9 апреля.
+    </title>
+    <title level="a">
+     Объявления
+    </title>
+    <title level="m">
+     Новости
+    </title>
+    <biblScope>
+     № 79 от 9 апреля
+    </biblScope>
+    <imprint>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="299" xml:id="Objavlenija_1856">
+    <title type="main">
+     Объявления. — «Русский инвалид» 1856, № 55 от 9 марта.
+    </title>
+    <title type="bibl">
+     Объявления // Русский инвалид. 1856. № 55 от 9 марта.
+    </title>
+    <title level="a">
+     Объявления
+    </title>
+    <title level="m">
+     Русский инвалид
+    </title>
+    <biblScope>
+     № 55 от 9 марта
+    </biblScope>
+    <imprint>
+     <date>
+      1856
+     </date>
+    </imprint>
+   </item>
+   <item n="300" xml:id="Objavlenija_1856_b">
+    <title type="main">
+     Объявления. — «Русский инвалид» 1856, № 9 от 12 января.
+    </title>
+    <title type="bibl">
+     Объявления // Русский инвалид. 1856. № 9 от 12 января.
+    </title>
+    <title level="a">
+     Объявления
+    </title>
+    <title level="m">
+     Русский инвалид
+    </title>
+    <biblScope>
+     № 9 от 12 января
+    </biblScope>
+    <imprint>
+     <date>
+      1856
+     </date>
+    </imprint>
+   </item>
+   <item n="301" xml:id="Objavlenija_1857">
+    <title type="main">
+     Объявления. — «Русский инвалид» 1857, № 9 от 11 января.
+    </title>
+    <title type="bibl">
+     Объявления // Русский инвалид. 1857. № 9 от 11 января.
+    </title>
+    <title level="a">
+     Объявления
+    </title>
+    <title level="m">
+     Русский инвалид
+    </title>
+    <biblScope>
+     № 9 от 11 января
+    </biblScope>
+    <imprint>
+     <date>
+      1857
+     </date>
+    </imprint>
+   </item>
+   <item n="302" xml:id="Objavlenija_1856_c">
+    <title type="main">
+     Объявления. — «Санкт-Петербургские ведомости» 1856, № 106 от 13 мая.
+    </title>
+    <title type="bibl">
+     Объявления // Санкт-Петербургские ведомости. 1856. № 106 от 13 мая.
+    </title>
+    <title level="a">
+     Объявления
+    </title>
+    <title level="m">
+     Санкт-Петербургские ведомости
+    </title>
+    <biblScope>
+     № 106 от 13 мая
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1856
+     </date>
+    </imprint>
+   </item>
+   <item n="303" xml:id="Objavlenija_1855">
+    <title type="main">
+     Объявления. — «Сев. Пчела» 1855, № 120 от 3 июня.
+    </title>
+    <title type="bibl">
+     Объявления // Сев. Пчела. 1855. № 120 от 3 июня.
+    </title>
+    <title level="a">
+     Объявления
+    </title>
+    <title level="m">
+     Сев. Пчела
+    </title>
+    <biblScope>
+     № 120 от 3 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1855
+     </date>
+    </imprint>
+   </item>
+   <item n="304" xml:id="Objavlenija_1855_b">
+    <title type="main">
+     Объявления. — «Сев. Пчела» 1855, № 195 от 7 сентября.
+    </title>
+    <title type="bibl">
+     Объявления // Сев. Пчела. 1855. № 195 от 7 сентября.
+    </title>
+    <title level="a">
+     Объявления
+    </title>
+    <title level="m">
+     Сев. Пчела
+    </title>
+    <biblScope>
+     № 195 от 7 сентября
+    </biblScope>
+    <imprint>
+     <date>
+      1855
+     </date>
+    </imprint>
+   </item>
+   <item n="305" xml:id="Ovsjannikov_N_P_Epizod_iz_zhizni_L_N_Tolstogo_1912">
+    <title type="main">
+     Овсянников Н. П. Эпизод из жизни Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Овсянников Н. П. Эпизод из жизни Л. Н. Толстого. М.: «Посредник», 1912.
+    </title>
+    <author>
+     Овсянников Н. П.
+    </author>
+    <title level="a">
+     Эпизод из жизни Л. Н. Толстого
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      «Посредник»
+     </publisher>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="306" xml:id="Ogareva_N_A_Pisma_k_rodnym_1917">
+    <title type="main">
+     Огарева Н. А. Письма к родным.
+    </title>
+    <title type="bibl">
+     Огарева Н. А. Письма к родным. // Русские пропилеи. № 4. М., 1917.
+    </title>
+    <author>
+     Огарева Н. А.
+    </author>
+    <title level="a">
+     Письма к родным
+    </title>
+    <title level="m">
+     Русские пропилеи
+    </title>
+    <biblScope>
+     № 4
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1917
+     </date>
+    </imprint>
+   </item>
+   <item n="307" xml:id="Ogareva_Ju_M_Vospominanija_1914">
+    <title type="main">
+     Огарева Ю. М. Воспоминания.
+    </title>
+    <title type="bibl">
+     Огарева Ю. М. Воспоминания // Голос минувшего. 1914. № 11.
+    </title>
+    <author>
+     Огарева Ю. М.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Голос минувшего
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1914
+     </date>
+    </imprint>
+   </item>
+   <item n="308" xml:id="Ogareva_Tuchkova_N_A_Vospominanija_1929">
+    <title type="main">
+     Огарева-Тучкова Н. А. Воспоминания.
+    </title>
+    <title type="bibl">
+     Огарева-Тучкова Н. А. Воспоминания. Л., 1929.
+    </title>
+    <author>
+     Огарева-Тучкова Н. А.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <imprint>
+     <pubPlace>
+      Л.
+     </pubPlace>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="309" xml:id="Olsufeva_A_G_Vospominanija_1911">
+    <title type="main">
+     Олсуфьева А. Г. Воспоминания.
+    </title>
+    <title type="bibl">
+     Олсуфьева А. Г. Воспоминания // Исторический вестник. 1911. № 3.
+    </title>
+    <author>
+     Олсуфьева А. Г.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="310" xml:id="Orlova_M_N_Vospominanija_o_L_N_Tolstom_1923">
+    <title type="main">
+     Орлов М. Н. Воспоминания о Л. Н. Толстом.
+    </title>
+    <title type="bibl">
+     Орлов М. Н. Воспоминания о Л. Н. Толстом // Новые пропилеи. М., 1923.
+    </title>
+    <author>
+     Орлова М. Н.
+    </author>
+    <title level="a">
+     Воспоминания о Л. Н. Толстом
+    </title>
+    <title level="m">
+     Новые пропилеи
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="311" xml:id="Ostrovskij_Aleksandr_Nikolaevich_Pismo_k_Nekrasovu_N_A_1916">
+    <title type="main">
+     Островский А. Н. Письмо к Некрасову Н. А.
+    </title>
+    <title type="bibl">
+     Островский А. Н. Письмо к Некрасову Н. А. // Архив села Карабихи. М., 1916.
+    </title>
+    <author>
+     Островский Александр Николаевич
+    </author>
+    <title level="a">
+     Письмо к Некрасову Н. А.
+    </title>
+    <title level="m">
+     Архив села Карабихи
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1916
+     </date>
+    </imprint>
+   </item>
+   <item n="312" xml:id="Otchet_imperatorskoj_Publichnoj_biblioteki_za_1883_god_1885">
+    <title type="main">
+     Отчет императорской Публичной библиотеки за 1883 год.
+    </title>
+    <title type="bibl">
+     Отчет императорской Публичной библиотеки за 1883 год. СПб., 1885.
+    </title>
+    <title level="a">
+     Отчет императорской Публичной библиотеки за 1883 год
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1885
+     </date>
+    </imprint>
+   </item>
+   <item n="313" xml:id="Otchet_imperatorskoj_Publichnoj_biblioteki_za_1884_god_1887">
+    <title type="main">
+     Отчет императорской Публичной библиотеки за 1884 год.
+    </title>
+    <title type="bibl">
+     Отчет императорской Публичной библиотеки за 1884 год. СПб., 1887.
+    </title>
+    <title level="a">
+     Отчет императорской Публичной библиотеки за 1884 год
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1887
+     </date>
+    </imprint>
+   </item>
+   <item n="314" xml:id="Otchet_o_zasedanii_Moskovskogo_gubernskogo_zemstva_18_dekabrja_1866_1866">
+    <title type="main">
+     Отчет о заседании Московского губернского земства 18 декабря 1866.
+    </title>
+    <title type="bibl">
+     Отчет о заседании Московского губернского земства 18 декабря 1866 // Московские ведомости. 1866. № 274 от 29 декабря.
+    </title>
+    <title level="a">
+     Отчет о заседании Московского губернского земства 18 декабря 1866
+    </title>
+    <title level="m">
+     Московские ведомости
+    </title>
+    <biblScope>
+     № 274 от 29 декабря
+    </biblScope>
+    <imprint>
+     <date>
+      1866
+     </date>
+    </imprint>
+   </item>
+   <item n="315" xml:id="Otchet_Tulskoj_gubernskoj_zemskoj_upravy_za_1877_1878_gg_1878">
+    <title type="main">
+     Отчет Тульской губернской земской управы за 1877–1878 гг.
+    </title>
+    <title type="bibl">
+     Отчет Тульской губернской земской управы за 1877–1878 гг. Тула, 1878.
+    </title>
+    <title level="a">
+     Отчет Тульской губернской земской управы за 1877–1878 гг.
+    </title>
+    <imprint>
+     <date>
+      1878
+     </date>
+    </imprint>
+   </item>
+   <item n="316" xml:id="Ocherednoj_spisok_lits_izbrannyh_v_prisjazhnye_zasedateli_po_Krapivenskomu_uezdu_Tulskoj_gub_na_1868_god_1868">
+    <title type="main">
+     Очередной список лиц, избранных в присяжные заседатели по Крапивенскому уезду Тульской губ. на 1868 год.
+    </title>
+    <title type="bibl">
+     Очередной список лиц, избранных в присяжные заседатели по Крапивенскому уезду Тульской губ. на 1868 год // Тульские губернские ведомости. 1868. № 7.
+    </title>
+    <title level="a">
+     Очередной список лиц, избранных в присяжные заседатели по Крапивенскому уезду Тульской губ. на 1868 год
+    </title>
+    <title level="m">
+     Тульские губернские ведомости
+    </title>
+    <biblScope>
+     № 7
+    </biblScope>
+    <imprint>
+     <date>
+      1868
+     </date>
+    </imprint>
+   </item>
+   <item n="317" xml:id="P_V_Annenkov_i_ego_druzja_1892">
+    <title type="main">
+     П. В. Анненков и его друзья.
+    </title>
+    <title type="bibl">
+     П. В. Анненков и его друзья. СПб., 1892.
+    </title>
+    <title level="a">
+     П. В. Анненков и его друзья
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1892
+     </date>
+    </imprint>
+   </item>
+   <item n="318" xml:id="Pamjati_Konstantina_Nikolaevicha_Leonteva_Sbornik_1911">
+    <title type="main">
+     Памяти Константина Николаевича Леонтьева.
+    </title>
+    <title type="bibl">
+     Памяти Константина Николаевича Леонтьева. Сборник, СПб., 1911.
+    </title>
+    <title level="a">
+     Памяти Константина Николаевича Леонтьева. Сборник
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="319" xml:id="Pamjatnaja_kniga_o_skonchavshihsja_v_Optinoj_pustyne_za_1841_god_1841">
+    <title type="main">
+     Памятная книга о скончавшихся в Оптиной пустыне за 1841 год.
+    </title>
+    <title type="bibl">
+     Памятная книга о скончавшихся в Оптиной пустыне за 1841 год.
+    </title>
+    <title level="a">
+     Памятная книга о скончавшихся в Оптиной пустыне за 1841 год
+    </title>
+    <imprint>
+     <date>
+      1841
+     </date>
+    </imprint>
+   </item>
+   <item n="320" xml:id="Panaev_Ivan_Ivanovich_Zametki_novogo_poeta_1861">
+    <title type="main">
+     Панаев И. И. Заметки нового поэта.
+    </title>
+    <title type="bibl">
+     Панаев И. И. Заметки нового поэта // Современник. 1861. № 3.
+    </title>
+    <author>
+     Панаев Иван Иванович
+    </author>
+    <title level="a">
+     Заметки нового поэта
+    </title>
+    <title level="m">
+     Современник
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1861
+     </date>
+    </imprint>
+   </item>
+   <item n="321" xml:id="Panaev_Ivan_Ivanovich_Literaturnye_vospominanija_1888">
+    <title type="main">
+     Панаев И. И. Литературные воспоминания.
+    </title>
+    <title type="bibl">
+     Панаев И. И. Литературные воспоминания. СПб., 1888.
+    </title>
+    <author>
+     Панаев Иван Иванович
+    </author>
+    <title level="a">
+     Литературные воспоминания
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1888
+     </date>
+    </imprint>
+   </item>
+   <item n="322" xml:id="Panaev_Ivan_Ivanovich_Pismo_k_Tolstomu_L_N_1928">
+    <title type="main">
+     Панаев И. И. Письмо к Толстому Л. Н.
+    </title>
+    <title type="bibl">
+     Панаев И. И. Письмо к Толстому Л. Н. // Красная новь. 1928. № 9.
+    </title>
+    <author>
+     Панаев Иван Иванович
+    </author>
+    <title level="a">
+     Письмо к Толстому Л. Н.
+    </title>
+    <title level="m">
+     Красная новь
+    </title>
+    <biblScope>
+     № 9
+    </biblScope>
+    <imprint>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="323" xml:id="Panaeva_A_Golovacheva_E_Ja_Vospominanija_1824_1870_1928">
+    <title type="main">
+     Панаева А. (Е. Я. Головачева). Воспоминания. 1824–1870.
+    </title>
+    <title type="bibl">
+     Панаева А. (Е. Я. Головачева). Воспоминания. 1824–1870. Л.: Academia, 1928.
+    </title>
+    <author>
+     Панаева А. (Головачева Е. Я.)
+    </author>
+    <title level="a">
+     Воспоминания. 1824–1870
+    </title>
+    <imprint>
+     <pubPlace>
+      Л.
+     </pubPlace>
+     <publisher>
+      Academia
+     </publisher>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="324" xml:id="Pankratov_A_Tolstoj_shkolnyj_uchitel_1912">
+    <title type="main">
+     Панкратов А. Толстой — школьный учитель.
+    </title>
+    <title type="bibl">
+     Панкратов А. Толстой — школьный учитель // Русское слово. 1912. № 257 от 7 ноября.
+    </title>
+    <author>
+     Панкратов А.
+    </author>
+    <title level="a">
+     Толстой — школьный учитель
+    </title>
+    <title level="m">
+     Русское слово
+    </title>
+    <biblScope>
+     № 257 от 7 ноября
+    </biblScope>
+    <imprint>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="325" xml:id="Pasport_vydannyj_Tolstomu_Tulskim_dvorjanskim_deputatskim_sobraniem">
+    <title type="main">
+     Паспорт, выданный Толстому Тульским дворянским депутатским собранием.
+    </title>
+    <title type="bibl">
+     Паспорт, выданный Толстому Тульским дворянским депутатским собранием (Военно-исторический архив в Москве).
+    </title>
+    <title level="a">
+     Паспорт, выданный Толстому Тульским дворянским депутатским собранием
+    </title>
+    <repository>
+     Военно-исторический архив
+    </repository>
+   </item>
+   <item n="326" xml:id="Pedagogicheskij_listok_1875">
+    <title type="main">
+     Педагогический листок. 1875. № 3.
+    </title>
+    <title type="bibl">
+     Педагогический листок. 1875. № 3.
+    </title>
+    <title level="a">
+     Педагогический листок
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1875
+     </date>
+    </imprint>
+   </item>
+   <item n="327" xml:id="Perepiska_I_N_Kramskogo_I_N_Kramskoj_i_P_M_Tretjakov_1869_1887_1936">
+    <title type="main">
+     Переписка И. Н. Крамского. И. Н. Крамской и П. М. Третьяков. 1869–1887.
+    </title>
+    <title type="bibl">
+     Переписка И. Н. Крамского. И. Н. Крамской и П. М. Третьяков. 1869–1887. М.: «Искусство», 1953.
+    </title>
+    <title level="a">
+     Переписка И. Н. Крамского. И. Н. Крамской и П. М. Третьяков. 1869–1887
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      «Искусство»
+     </publisher>
+     <date>
+      1936
+     </date>
+    </imprint>
+   </item>
+   <item n="328" xml:id="Peterson_N_P_Iz_zapisok_byvshego_uchitelja_1909">
+    <title type="main">
+     Петерсон Н. П. Из записок бывшего учителя.
+    </title>
+    <title type="bibl">
+     Петерсон Н. П. Из записок бывшего учителя // Международный толстовский альманах, составленный П. А. Сергеенко. М., 1909.
+    </title>
+    <author>
+     Петерсон Н. П.
+    </author>
+    <title level="a">
+     Из записок бывшего учителя
+    </title>
+    <title level="m">
+     Международный толстовский альманах, составленный П. А. Сергеенко
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="329" xml:id="Peterson_N_P_N_F_Fedorov_i_ego_kniga_Filosofija_obschego_dela_1912">
+    <title type="main">
+     Петерсон Н. П. Н. Ф. Федоров и его книга «Философия общего дела».
+    </title>
+    <title type="bibl">
+     Петерсон Н. П. Н. Ф. Федоров и его книга «Философия общего дела». Верный, 1912.
+    </title>
+    <author>
+     Петерсон Н. П.
+    </author>
+    <title level="a">
+     Н. Ф. Федоров и его книга «Философия общего дела»
+    </title>
+    <imprint>
+     <pubPlace>
+      Верный
+     </pubPlace>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="330" xml:id="Petrov_I_I_Pismo_k_Chertkovu_V_G_1948">
+    <title type="main">
+     Петров И. И. Письмо к Черткову В. Г.
+    </title>
+    <title type="bibl">
+     Петров И. И. Письмо к Черткову В. Г. // Летописи Государственного Литературного Музея. Кн. 12. М., 1948.
+    </title>
+    <author>
+     Петров И. И.
+    </author>
+    <title level="a">
+     Письмо к Черткову В. Г.
+    </title>
+    <title level="m">
+     Летописи Государственного Литературного Музея
+    </title>
+    <biblScope>
+     Кн. 12
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1948
+     </date>
+    </imprint>
+   </item>
+   <item n="331" xml:id="Petrov_N_I_Epizod_iz_palomnichestva_L_N_Tolstogo">
+    <title type="main">
+     Петров Н. И. Эпизод из паломничества Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Петров Н. И. Эпизод из паломничества Л. Н. Толстого (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Петров Н. И.
+    </author>
+    <title level="a">
+     Эпизод из паломничества Л. Н. Толстого
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+    </imprint>
+   </item>
+   <item n="332" xml:id="Pisarev_Dmitrij_Ivanovich_Promahi_nezreloj_mysli_1864">
+    <title type="main">
+     Писарев Д. И. Промахи незрелой мысли.
+    </title>
+    <title type="bibl">
+     Писарев Д. И. Промахи незрелой мысли // Русское слово. 1864. № 12.
+    </title>
+    <author>
+     Писарев Дмитрий Иванович
+    </author>
+    <title level="a">
+     Промахи незрелой мысли
+    </title>
+    <title level="m">
+     Русское слово
+    </title>
+    <biblScope>
+     № 12
+    </biblScope>
+    <imprint>
+     <date>
+      1864
+     </date>
+    </imprint>
+   </item>
+   <item n="333" xml:id="Pisarev_Dmitrij_Ivanovich_Staroe_barstvo_1868">
+    <title type="main">
+     Писарев Д. И. Старое барство.
+    </title>
+    <title type="bibl">
+     Писарев Д. И. Старое барство // Отечественные записки. 1868. № 2.
+    </title>
+    <author>
+     Писарев Дмитрий Иванович
+    </author>
+    <title level="a">
+     Старое барство
+    </title>
+    <title level="m">
+     Отечественные записки
+    </title>
+    <biblScope>
+     № 2
+    </biblScope>
+    <imprint>
+     <date>
+      1868
+     </date>
+    </imprint>
+   </item>
+   <item n="334" xml:id="Pisma_L_N_Tolstogo_sobrannye_i_redaktirovannye_P_A_Sergeenko_1910">
+    <title type="main">
+     Письма Л. Н. Толстого, собранные и редактированные П. А. Сергеенко. 1848–1910.
+    </title>
+    <title type="bibl">
+     Письма Л. Н. Толстого, собранные и редактированные П. А. Сергеенко. 1848–1910. М.: Кн-во «Книга», 1910.
+    </title>
+    <title level="a">
+     Письма Л. Н. Толстого, собранные и редактированные П. А. Сергеенко
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Кн-во «Книга»
+     </publisher>
+     <date>
+      1910
+     </date>
+    </imprint>
+   </item>
+   <item n="335" xml:id="Pisma_Tolstogo_i_k_Tolstomu_1928">
+    <title type="main">
+     Письма Толстого и к Толстому.
+    </title>
+    <title type="bibl">
+     Письма Толстого и к Толстому. М.: Гослитиздат, 1928 (Труды Библиотеки СССР им. В. И. Ленина).
+    </title>
+    <title level="a">
+     Письма Толстого и к Толстому
+    </title>
+    <biblScope>
+     Т. 17
+    </biblScope>
+    <repository>
+     Труды Библиотеки СССР им. В. И. Ленина
+    </repository>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Гослитиздат
+     </publisher>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="336" xml:id="Plaksin_S_Gr_L_N_Tolstoj_sredi_detej_1903">
+    <title type="main">
+     Плаксин С. Гр. Л. Н. Толстой среди детей.
+    </title>
+    <title type="bibl">
+     Плаксин С. Гр. Л. Н. Толстой среди детей. М., 1903.
+    </title>
+    <author>
+     Плаксин С.
+    </author>
+    <title level="a">
+     Гр. Л. Н. Толстой среди детей
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1903
+     </date>
+    </imprint>
+   </item>
+   <item n="337" xml:id="Pobedonostsev_K_D_Pismo_k_Aleksandru_III_1926">
+    <title type="main">
+     Победоносцев К. Д. Письмо к Александру III.
+    </title>
+    <title type="bibl">
+     Победоносцев К. Д. Письмо к Александру III // Новая Москва. 1926. № 71.
+    </title>
+    <author>
+     Победоносцев К. Д.
+    </author>
+    <title level="a">
+     Письмо к Александру III
+    </title>
+    <title level="m">
+     Новая Москва
+    </title>
+    <biblScope>
+     № 71
+    </biblScope>
+    <imprint>
+     <date>
+      1926
+     </date>
+    </imprint>
+   </item>
+   <item n="338" xml:id="Pobedonostsev_K_P_i_ego_korrespondenty_Pisma_i_zapiski_1923">
+    <title type="main">
+     Победоносцев К. П. и его корреспонденты. Письма и записки. Т. 1.
+    </title>
+    <title type="bibl">
+     Победоносцев К. П. и его корреспонденты. Письма и записки. Т. 1. М.–Пд.: Госиздат, 1923 (Труды Гос. Румянцевского музея).
+    </title>
+    <title level="a">
+     Победоносцев К. П. и его корреспонденты. Письма и записки
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.–Пд.
+     </pubPlace>
+     <publisher>
+      Госиздат
+     </publisher>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="339" xml:id="Pogodin_Mihail_Petrovich_Dnevnik">
+    <title type="main">
+     Погодин М. П. Дневник.
+    </title>
+    <title type="bibl">
+     Погодин М. П. Дневник (Российская государственная библиотека).
+    </title>
+    <author>
+     Погодин Михаил Петрович
+    </author>
+    <title level="a">
+     Дневник
+    </title>
+    <repository>
+     Российская государственная библиотека
+    </repository>
+   </item>
+   <item n="340" xml:id="Polivanov_I_L_L_N_Tolstoj_v_1881_g_zapis_odnogo_dialoga">
+    <title type="main">
+     Поливанов И. Л. Л. Н. Толстой в 1881 г. (запись одного диалога).
+    </title>
+    <title type="bibl">
+     Поливанов И. Л. Л. Н. Толстой в 1881 г. (запись одного диалога) (Государственный музей Л. Н. Толстого в Москве)
+    </title>
+    <author>
+     Поливанов И. Л.
+    </author>
+    <title level="a">
+     Л. Н. Толстой в 1881 г. (запись одного диалога)
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+    </imprint>
+   </item>
+   <item n="341" xml:id="Polonskij_Jakov_Petrovich_Pismo_k_Shtakenshnejder_M_F_1919">
+    <title type="main">
+     Полонский Я. П. Письмо к Штакеншнейдер М. Ф.
+    </title>
+    <title type="bibl">
+     Полонский Я. П. Письмо к Штакеншнейдер М. Ф. // Голос минувшего. 1919. №№ 1–4.
+    </title>
+    <author>
+     Полонский Яков Петрович
+    </author>
+    <title level="a">
+     Письмо к Штакеншнейдер М. Ф.
+    </title>
+    <title level="m">
+     Голос минувшего
+    </title>
+    <biblScope>
+     №№ 1–4
+    </biblScope>
+    <imprint>
+     <date>
+      1919
+     </date>
+    </imprint>
+   </item>
+   <item n="342" xml:id="Polonskij_Jakov_Petrovich_Po_povodu_poslednej_povesti_gr_L_N_Tolstogo_1863">
+    <title type="main">
+     Полонский Я. П. По поводу последней повести гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Полонский Я. П. По поводу последней повести гр. Л. Н. Толстого // Время. 1863. № 3.
+    </title>
+    <author>
+     Полонский Яков Петрович
+    </author>
+    <title level="a">
+     По поводу последней повести гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Время
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1863
+     </date>
+    </imprint>
+   </item>
+   <item n="343" xml:id="Poltoratskij_V_Vospominanija_1893">
+    <title type="main">
+     Полторацкий В. Воспоминания.
+    </title>
+    <title type="bibl">
+     Полторацкий В. Воспоминания // Исторический вестник. 1893. № 6.
+    </title>
+    <author>
+     Полторацкий В.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 6
+    </biblScope>
+    <imprint>
+     <date>
+      1893
+     </date>
+    </imprint>
+   </item>
+   <item n="344" xml:id="Popov_P_S_Kommentarii_k_romanu_iz_epohi_Petra_I_1936">
+    <title type="main">
+     Попов П. С. Комментарии к роману из эпохи Петра I.
+    </title>
+    <title type="bibl">
+     Попов П. С. Комментарии к роману из эпохи Петра I // Толстой Л. Н. Полное собрание сочинений. Юбилейное издание. Т. 17. 1936.
+    </title>
+    <author>
+     Попов П. С.
+    </author>
+    <title level="a">
+     Комментарии к роману из эпохи Петра I
+    </title>
+    <title level="m">
+     Толстой Л. Н. Полное собрание сочинений. Юбилейное издание
+    </title>
+    <biblScope>
+     Т. 17
+    </biblScope>
+    <imprint>
+     <date>
+      1936
+     </date>
+    </imprint>
+   </item>
+   <item n="345" xml:id="Postanovlenija_i_rasporjazhenija_pravitelstva_1862">
+    <title type="main">
+     Постановления и распоряжения правительства.
+    </title>
+    <title type="bibl">
+     Постановления и распоряжения правительства // Московские ведомости. 1862. № 131 от 16 июня.
+    </title>
+    <title level="a">
+     Постановления и распоряжения правительства
+    </title>
+    <title level="m">
+     Московские ведомости
+    </title>
+    <biblScope>
+     № 131 от 16 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1862
+     </date>
+    </imprint>
+   </item>
+   <item n="346" xml:id="Pravitelstvennyj_vestnik_1872">
+    <title type="main">
+     Правительственный вестник. 1872. № 269 от 12 ноября.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1872. № 269 от 12 ноября.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 269 от 12 ноября
+    </biblScope>
+    <imprint>
+     <date>
+      1872
+     </date>
+    </imprint>
+   </item>
+   <item n="347" xml:id="Pravitelstvennyj_vestnik_1873">
+    <title type="main">
+     Правительственный вестник. 1873. № 275.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1873. № 275.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 275
+    </biblScope>
+    <imprint>
+     <date>
+      1873
+     </date>
+    </imprint>
+   </item>
+   <item n="348" xml:id="Pravitelstvennyj_vestnik_1875">
+    <title type="main">
+     Правительственный вестник. 1875. № 127 от 11 июня.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1875. № 127 от 11 июня.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 127 от 11 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1875
+     </date>
+    </imprint>
+   </item>
+   <item n="349" xml:id="Pravitelstvennyj_vestnik_1880">
+    <title type="main">
+     Правительственный вестник. 1880. № 122 от 1 июня.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1880. № 122 от 1 июня.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 122 от 1 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1880
+     </date>
+    </imprint>
+   </item>
+   <item n="350" xml:id="Pravitelstvennyj_vestnik_1880_b">
+    <title type="main">
+     Правительственный вестник. 1880. № 145 от 29 июня.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1880. № 145 от 29 июня.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 145 от 29 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1880
+     </date>
+    </imprint>
+   </item>
+   <item n="351" xml:id="Pravitelstvennyj_vestnik_1880_c">
+    <title type="main">
+     Правительственный вестник. 1880. № 152 от 8 июля.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1880. № 152 от 8 июля.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 152 от 8 июля
+    </biblScope>
+    <imprint>
+     <date>
+      1880
+     </date>
+    </imprint>
+   </item>
+   <item n="352" xml:id="Pravitelstvennyj_vestnik_1880_d">
+    <title type="main">
+     Правительственный вестник. 1880. № 186 от 20 августа.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1880. № 186 от 20 августа.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 186 от 20 августа
+    </biblScope>
+    <imprint>
+     <date>
+      1880
+     </date>
+    </imprint>
+   </item>
+   <item n="353" xml:id="Pravitelstvennyj_vestnik_1885">
+    <title type="main">
+     Правительственный вестник. 1885. № 277 от 19 декабря.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1885. № 277 от 19 декабря.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 277 от 19 декабря
+    </biblScope>
+    <imprint>
+     <date>
+      1885
+     </date>
+    </imprint>
+   </item>
+   <item n="354" xml:id="Pravitelstvennyj_vestnik_1885_b">
+    <title type="main">
+     Правительственный вестник. 1885. № 280.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1885. № 280.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 280
+    </biblScope>
+    <imprint>
+     <date>
+      1885
+     </date>
+    </imprint>
+   </item>
+   <item n="355" xml:id="Pravitelstvennyj_vestnik_1885_c">
+    <title type="main">
+     Правительственный вестник. 1885. № 282 от 25 декабря.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1885. № 282 от 25 декабря.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 282 от 25 декабря
+    </biblScope>
+    <imprint>
+     <date>
+      1885
+     </date>
+    </imprint>
+   </item>
+   <item n="356" xml:id="Pravitelstvennyj_vestnik_1886">
+    <title type="main">
+     Правительственный вестник. 1886. № 118 от 1 июня.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1886. № 118 от 1 июня.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 118 от 1 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="357" xml:id="Pravitelstvennyj_vestnik_1886_b">
+    <title type="main">
+     Правительственный вестник. 1886. № 274 от 14 декабря.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1886. № 274 от 14 декабря.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 274 от 14 декабря
+    </biblScope>
+    <imprint>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="358" xml:id="Pravitelstvennyj_vestnik_1886_c">
+    <title type="main">
+     Правительственный вестник. 1886. № 50.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1886. № 50.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 50
+    </biblScope>
+    <imprint>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="359" xml:id="Pravitelstvennyj_vestnik_1887">
+    <title type="main">
+     Правительственный вестник. 1887. № 125 от 14 июня.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1887. № 125 от 14 июня.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 125 от 14 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1887
+     </date>
+    </imprint>
+   </item>
+   <item n="360" xml:id="Pravitelstvennyj_vestnik_1887_b">
+    <title type="main">
+     Правительственный вестник. 1887. № 142 от 2 июля.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1887. № 142 от 2 июля.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 142 от 2 июля
+    </biblScope>
+    <imprint>
+     <date>
+      1887
+     </date>
+    </imprint>
+   </item>
+   <item n="361" xml:id="Pravitelstvennyj_vestnik_1887_c">
+    <title type="main">
+     Правительственный вестник. 1887. № 154 от 19 июля.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1887. № 154 от 19 июля.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 154 от 19 июля
+    </biblScope>
+    <imprint>
+     <date>
+      1887
+     </date>
+    </imprint>
+   </item>
+   <item n="362" xml:id="Pravitelstvennyj_vestnik_1887_d">
+    <title type="main">
+     Правительственный вестник. 1887. № 31 от 3 февраля.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1887. № 31 от 3 февраля.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 31 от 3 февраля
+    </biblScope>
+    <imprint>
+     <date>
+      1887
+     </date>
+    </imprint>
+   </item>
+   <item n="363" xml:id="Pravitelstvennyj_vestnik_1887_e">
+    <title type="main">
+     Правительственный вестник. 1887. № 46 от 1 марта.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1887. № 46 от 1 марта.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 46 от 1 марта
+    </biblScope>
+    <imprint>
+     <date>
+      1887
+     </date>
+    </imprint>
+   </item>
+   <item n="364" xml:id="Pravitelstvennyj_vestnik_1889">
+    <title type="main">
+     Правительственный вестник. 1889. № 131 от 18 июня.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1889. № 131 от 18 июня.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 131 от 18 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1889
+     </date>
+    </imprint>
+   </item>
+   <item n="365" xml:id="Pravitelstvennyj_vestnik_1889_b">
+    <title type="main">
+     Правительственный вестник. 1889. № 142 от 2 июля.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1889. № 142 от 2 июля.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 142 от 2 июля
+    </biblScope>
+    <imprint>
+     <date>
+      1889
+     </date>
+    </imprint>
+   </item>
+   <item n="366" xml:id="Pravitelstvennyj_vestnik_1889_c">
+    <title type="main">
+     Правительственный вестник. 1889. № 159 от 22 июля.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1889. № 159 от 22 июля.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 159 от 22 июля
+    </biblScope>
+    <imprint>
+     <date>
+      1889
+     </date>
+    </imprint>
+   </item>
+   <item n="367" xml:id="Pravitelstvennyj_vestnik_1889_d">
+    <title type="main">
+     Правительственный вестник. 1889. № 188 от 27 августа.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1889. № 188 от 27 августа.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 188 от 27 августа
+    </biblScope>
+    <imprint>
+     <date>
+      1889
+     </date>
+    </imprint>
+   </item>
+   <item n="368" xml:id="Pravitelstvennyj_vestnik_1889_e">
+    <title type="main">
+     Правительственный вестник. 1889. № 59 от 16 марта.
+    </title>
+    <title type="bibl">
+     Правительственный вестник. 1889. № 59 от 16 марта.
+    </title>
+    <title level="m">
+     Правительственный вестник
+    </title>
+    <biblScope>
+     № 59 от 16 марта
+    </biblScope>
+    <imprint>
+     <date>
+      1889
+     </date>
+    </imprint>
+   </item>
+   <item n="369" xml:id="Priselkov_A_V_Pervaja_postanovka_Vlasti_tmy_na_ljubitelskoj_stsene_v_1890_godu_iz_vospominanij_1909">
+    <title type="main">
+     Приселков А. В. Первая постановка «Власти тьмы» на любительской сцене в 1890 году (из воспоминаний).
+    </title>
+    <title type="bibl">
+     Приселков А. В. Первая постановка «Власти тьмы» на любительской сцене в 1890 году (из воспоминаний) // Ежегодник императорских театров. Кн. 1. СПб., 1909.
+    </title>
+    <author>
+     Приселков А. В.
+    </author>
+    <title level="a">
+     Первая постановка «Власти тьмы» на любительской сцене в 1890 году (из воспоминаний)
+    </title>
+    <title level="m">
+     Ежегодник императорских театров
+    </title>
+    <biblScope>
+     Кн. 1
+    </biblScope>
+    <repository>
+     из воспоминаний)
+    </repository>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="370" xml:id="Protokol_zasedanija_Komiteta_gramotnosti_1874">
+    <title type="main">
+     Протокол заседания Комитета грамотности.
+    </title>
+    <title type="bibl">
+     Протокол заседания Комитета грамотности // Московские епархиальные ведомости. 1874. № 10.
+    </title>
+    <title level="a">
+     Протокол заседания Комитета грамотности
+    </title>
+    <title level="m">
+     Московские епархиальные ведомости
+    </title>
+    <biblScope>
+     № 10
+    </biblScope>
+    <imprint>
+     <date>
+      1874
+     </date>
+    </imprint>
+   </item>
+   <item n="371" xml:id="Protokol_zasedanija_Obschestva_ljubitelej_rossijskoj_slovesnosti_1859">
+    <title type="main">
+     Протокол заседания Общества любителей российской словесности.
+    </title>
+    <title type="bibl">
+     Протокол заседания Общества любителей российской словесности // Московские ведомости. 1859, № 59 от 10 марта.
+    </title>
+    <title level="a">
+     Протокол заседания Общества любителей российской словесности
+    </title>
+    <title level="m">
+     Московские ведомости
+    </title>
+    <biblScope>
+     № 59 от 10 марта
+    </biblScope>
+    <imprint>
+     <date>
+      1859
+     </date>
+    </imprint>
+   </item>
+   <item n="372" xml:id="Prugavin_A_S_O_Lve_Tolstom_i_o_tolstovtsah_1911">
+    <title type="main">
+     Пругавин А. С. О Льве Толстом и о толстовцах.
+    </title>
+    <title type="bibl">
+     Пругавин А. С. О Льве Толстом и о толстовцах. М., 1911.
+    </title>
+    <author>
+     Пругавин А. С.
+    </author>
+    <title level="a">
+     О Льве Толстом и о толстовцах
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="373" xml:id="Publichnaja_biblioteka_SSSR_im_V_I_Lenina_1929">
+    <title type="main">
+     Публичная библиотека СССР им. В. И. Ленина. Сб. 2. М., 1929.
+    </title>
+    <title type="bibl">
+     Публичная библиотека СССР им. В. И. Ленина. Сб. 2. М., 1929.
+    </title>
+    <title level="a">
+     Публичная библиотека СССР им. В. И. Ленина.
+    </title>
+    <biblScope>
+     Сб. 2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="374" xml:id="Pushkin_Aleksandr_Sergeevich_Sochinenija_1855">
+    <title type="main">
+     Пушкин А. С. Сочинения. Т. 5. / Ред. П. В. Анненкова. 1855.
+    </title>
+    <title type="bibl">
+     Пушкин А. С. Сочинения. Т. 5. / Ред. П. В. Анненкова. 1855.
+    </title>
+    <author>
+     Пушкин Александр Сергеевич
+    </author>
+    <editor>
+     П. В. Анненков
+    </editor>
+    <title level="a">
+     Сочинения
+    </title>
+    <biblScope>
+     Т. 5
+    </biblScope>
+    <imprint>
+     <date>
+      1855
+     </date>
+    </imprint>
+   </item>
+   <item n="375" xml:id="Pchelnikov_P_M_Iz_dnevnika_1909">
+    <title type="main">
+     Пчельников П. М. Из дневника.
+    </title>
+    <title type="bibl">
+     Пчельников П. М. Из дневника // Международный толстовский альманах, составленный П. А. Сергеенко. М., 1909.
+    </title>
+    <author>
+     Пчельников П. М.
+    </author>
+    <title level="a">
+     Из дневника
+    </title>
+    <title level="m">
+     Международный толстовский альманах, составленный П. А. Сергеенко
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="376" xml:id="Azbuka_gr_L_N_Tolstogo_1873">
+    <title type="main">
+     Р. «Азбука» гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Р. «Азбука» гр. Л. Н. Толстого // Народная школа. 1873. № 6.
+    </title>
+    <title level="a">
+     Азбука гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Народная школа
+    </title>
+    <biblScope>
+     № 6
+    </biblScope>
+    <imprint>
+     <date>
+      1873
+     </date>
+    </imprint>
+   </item>
+   <item n="377" xml:id="Raskolnikov_F_Tsenzurnye_mytarstva_L_N_Tolstogo_dramaturga_1928">
+    <title type="main">
+     Раскольников Ф. Цензурные мытарства Л. Н. Толстого-драматурга.
+    </title>
+    <title type="bibl">
+     Раскольников Ф. Цензурные мытарства Л. Н. Толстого-драматурга // Красная новь. 1928. № 11.
+    </title>
+    <author>
+     Раскольников Ф.
+    </author>
+    <title level="a">
+     Цензурные мытарства Л. Н. Толстого-драматурга
+    </title>
+    <title level="m">
+     Красная новь
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="378" xml:id="Rezener_Azbuka_gr_L_N_Tolstogo_1873">
+    <title type="main">
+     Резенер. Азбука гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Резенер. Азбука гр. Л. Н. Толстого // Современность. 1873. № 23.
+    </title>
+    <author>
+     Резенер
+    </author>
+    <title level="a">
+     Азбука гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Современность
+    </title>
+    <biblScope>
+     № 23
+    </biblScope>
+    <imprint>
+     <date>
+      1873
+     </date>
+    </imprint>
+   </item>
+   <item n="379" xml:id="Rezener_Azbuka_gr_L_N_Tolstogo_1873_b">
+    <title type="main">
+     Резенер. Азбука гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Резенер. Азбука гр. Л. Н. Толстого // Современность. 1873. № 24.
+    </title>
+    <author>
+     Резенер
+    </author>
+    <title level="a">
+     Азбука гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Современность
+    </title>
+    <biblScope>
+     № 24
+    </biblScope>
+    <imprint>
+     <date>
+      1873
+     </date>
+    </imprint>
+   </item>
+   <item n="380" xml:id="Repin_Ilja_Efimovich_Tolstoj_Lev_Nikolaevich_Perepiska_s_L_N_Tolstym_i_ego_semej_1949">
+    <title type="main">
+     Репин И. Е. и Толстой Л. Н. 1. Переписка с Л. Н. Толстым и его семьей.
+    </title>
+    <title type="bibl">
+     Репин И. Е. и Толстой Л. Н. 1. Переписка с Л. Н. Толстым и его семьей. / Письма подготовлены к печати и примеч. к ним составлены В. А. Ждановым и Э. Е. Зайденшнур. М.–Л.: «Искусство», 1949.
+    </title>
+    <author>
+     Репин Илья Ефимович, Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Переписка с Л. Н. Толстым и его семьей
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      «Искусство»
+     </publisher>
+     <date>
+      1949
+     </date>
+    </imprint>
+   </item>
+   <item n="381" xml:id="Rech_1913">
+    <title type="main">
+     Речь. 1913. № 305.
+    </title>
+    <title type="bibl">
+     Речь. 1913. № 305.
+    </title>
+    <title level="a">
+     Речь
+    </title>
+    <biblScope>
+     № 305
+    </biblScope>
+    <imprint>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="382" xml:id="Rozanov_Vasilij_Vasilevich_Literaturnye_izgnanniki_1913">
+    <title type="main">
+     Розанов В. В. Литературные изгнанники. Т. 1.
+    </title>
+    <title type="bibl">
+     Розанов В. В. Литературные изгнанники. Т. 1. СПб., 1913.
+    </title>
+    <author>
+     Розанов Василий Васильевич
+    </author>
+    <title level="a">
+     Литературные изгнанники
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="383" xml:id="Rummel_V_V_Golubtsev_V_V_Rodoslovnyj_sbornik_russkih_dvorjanskih_familij_1887">
+    <title type="main">
+     Руммель В. В. и Голубцов В. В. Родословный сборник русских дворянских фамилий. Т. 2.
+    </title>
+    <title type="bibl">
+     Руммель В. В. и Голубцов В. В. Родословный сборник русских дворянских фамилий. Т. 2. СПб., 1887.
+    </title>
+    <author>
+     Руммель В. В.,  Голубцев В. В.
+    </author>
+    <title level="a">
+     Родословный сборник русских дворянских фамилий
+    </title>
+    <biblScope>
+     Т. 2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1887
+     </date>
+    </imprint>
+   </item>
+   <item n="384" xml:id="Rusanov_G_A_Vospominanija_1937">
+    <title type="main">
+     Русанов Г. А. Воспоминания.
+    </title>
+    <title type="bibl">
+     Русанов Г. А. Воспоминания // Русанов А. Г. Воспоминания о Л. Н. Толстом. Воронеж, обл. кн-во, 1937.
+    </title>
+    <author>
+     Русанов Г. А.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Русанов А. Г. Воспоминания о Л. Н. Толстом
+    </title>
+    <imprint>
+     <pubPlace>
+      Воронеж
+     </pubPlace>
+     <date>
+      1937
+     </date>
+    </imprint>
+   </item>
+   <item n="385" xml:id="Rusanov_G_A_Poezdka_v_Jasnuju_Poljanu_24_25_avgusta_1883_g_1912">
+    <title type="main">
+     Русанов Г. А. Поездка в Ясную Поляну 24–25 августа 1883 г.
+    </title>
+    <title type="bibl">
+     Русанов Г. А. Поездка в Ясную Поляну 24–25 августа 1883 г. // Толстовский ежегодник 1912 г. 1912.
+    </title>
+    <author>
+     Русанов Г. А.
+    </author>
+    <title level="a">
+     Поездка в Ясную Поляну 24–25 августа 1883 г.
+    </title>
+    <title level="m">
+     Толстовский ежегодник 1912 г.
+    </title>
+    <imprint>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="386" xml:id="Russkaja_mysl_1883">
+    <title type="main">
+     Русская мысль. 1883. № 4.
+    </title>
+    <title type="bibl">
+     Русская мысль. 1883. № 4.
+    </title>
+    <title level="a">
+     Русская мысль
+    </title>
+    <biblScope>
+     № 4
+    </biblScope>
+    <imprint>
+     <date>
+      1883
+     </date>
+    </imprint>
+   </item>
+   <item n="387" xml:id="Russkie_propilei_Materialy_po_istorii_russkoj_mysli_i_literatury_1915">
+    <title type="main">
+     Русские пропилеи. Т. 1. Материалы по истории русской мысли и литературы..
+    </title>
+    <title type="bibl">
+     Русские пропилеи. Т. 1. Материалы по истории русской мысли и литературы. / Собрал и подготовил к печати М. Гершензон. М.: Изд. М. и С. Сабашниковых, 1915.
+    </title>
+    <title level="a">
+     Русские пропилеи. Материалы по истории русской мысли и литературы
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. М. и С. Сабашниковых
+     </publisher>
+     <date>
+      1915
+     </date>
+    </imprint>
+   </item>
+   <item n="388" xml:id="Russkie_propilei_Materialy_po_istorij_russkoj_mysli_i_literatury_1917">
+    <title type="main">
+     Русские пропилеи. Т. 4. Материалы по историй русской мысли и литературы.
+    </title>
+    <title type="bibl">
+     Русские пропилеи. Т. 4. Материалы по историй русской мысли и литературы. / Собрал и приготовил к печати М. Гершензон. М.: Изд. М. и С. Сабашниковых, 1917.
+    </title>
+    <title level="a">
+     Русские пропилеи. Материалы по историй русской мысли и литературы
+    </title>
+    <biblScope>
+     Т. 4
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. М. и С. Сабашниковых
+     </publisher>
+     <date>
+      1917
+     </date>
+    </imprint>
+   </item>
+   <item n="389" xml:id="Russkij_arhiv_1903">
+    <title type="main">
+     Русский архив. 1903. № 3.
+    </title>
+    <title type="bibl">
+     Русский архив. 1903. № 3.
+    </title>
+    <title level="a">
+     Русский архив
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1903
+     </date>
+    </imprint>
+   </item>
+   <item n="390" xml:id="Russkij_invalid_1854">
+    <title type="main">
+     Русский инвалид. 1854. № 201.
+    </title>
+    <title type="bibl">
+     Русский инвалид. 1854. № 201.
+    </title>
+    <title level="a">
+     Русский инвалид
+    </title>
+    <biblScope>
+     № 201
+    </biblScope>
+    <imprint>
+     <date>
+      1854
+     </date>
+    </imprint>
+   </item>
+   <item n="391" xml:id="Russkoe_obozrenie_1896">
+    <title type="main">
+     Русское обозрение. 1896. № 11.
+    </title>
+    <title type="bibl">
+     Русское обозрение. 1896. № 11.
+    </title>
+    <title level="a">
+     Русское обозрение
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1896
+     </date>
+    </imprint>
+   </item>
+   <item n="392" xml:id="Saltykov_Schedrin_Mihail_Evgrafovich_Pisma_1924">
+    <title type="main">
+     Салтыков-Щедрин М. Е. Письма. 1845–1889.
+    </title>
+    <title type="bibl">
+     Салтыков-Щедрин М. Е. Письма. 1845–1889. М.: Госиздат, 1924.
+    </title>
+    <author>
+     Салтыков-Щедрин Михаил Евграфович
+    </author>
+    <title level="a">
+     Письма
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Госиздат
+     </publisher>
+     <date>
+      1924
+     </date>
+    </imprint>
+   </item>
+   <item n="393" xml:id="Sankt_Peterburgskie_vedomosti_1855">
+    <title type="main">
+     Санкт-Петербургские ведомости. 1855. № 204 от 20 сентября.
+    </title>
+    <title type="bibl">
+     Санкт-Петербургские ведомости. 1855. № 204 от 20 сентября.
+    </title>
+    <title level="m">
+     Санкт-Петербургские ведомости
+    </title>
+    <biblScope>
+     № 204 от 20 сентября
+    </biblScope>
+    <imprint>
+     <date>
+      1855
+     </date>
+    </imprint>
+   </item>
+   <item n="394" xml:id="Sankt_Peterburgskie_vedomosti_1856">
+    <title type="main">
+     Санкт-Петербургские ведомости. 1856. № 218 от 6 октября.
+    </title>
+    <title type="bibl">
+     Санкт-Петербургские ведомости. 1856. № 218 от 6 октября.
+    </title>
+    <title level="m">
+     Санкт-Петербургские ведомости
+    </title>
+    <biblScope>
+     № 218 от 6 октября
+    </biblScope>
+    <imprint>
+     <date>
+      1856
+     </date>
+    </imprint>
+   </item>
+   <item n="395" xml:id="Sankt_Peterburgskie_vedomosti_1857">
+    <title type="main">
+     Санкт-Петербургские ведомости. 1857. № 210 от 28 сентября.
+    </title>
+    <title type="bibl">
+     Санкт-Петербургские ведомости. 1857. № 210 от 28 сентября.
+    </title>
+    <title level="m">
+     Санкт-Петербургские ведомости
+    </title>
+    <biblScope>
+     № 210 от 28 сентября
+    </biblScope>
+    <imprint>
+     <date>
+      1857
+     </date>
+    </imprint>
+   </item>
+   <item n="396" xml:id="Sankt_Peterburgskie_vedomosti_1860">
+    <title type="main">
+     Санкт-Петербургские ведомости. 1860. № 117.
+    </title>
+    <title type="bibl">
+     Санкт-Петербургские ведомости. 1860. № 117.
+    </title>
+    <title level="m">
+     Санкт-Петербургские ведомости
+    </title>
+    <biblScope>
+     № 117
+    </biblScope>
+    <imprint>
+     <date>
+      1860
+     </date>
+    </imprint>
+   </item>
+   <item n="397" xml:id="Sankt_Peterburgskie_vedomosti_1863">
+    <title type="main">
+     Санкт-Петербургские ведомости. 1863. № 144 от 27 июня.
+    </title>
+    <title type="bibl">
+     Санкт-Петербургские ведомости. 1863. № 144 от 27 июня.
+    </title>
+    <title level="m">
+     Санкт-Петербургские ведомости
+    </title>
+    <biblScope>
+     № 144 от 27 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1863
+     </date>
+    </imprint>
+   </item>
+   <item n="398" xml:id="Sankt_Peterburgskie_vedomosti_1863_b">
+    <title type="main">
+     Санкт-Петербургские ведомости. 1863. № 145 от 28 июня.
+    </title>
+    <title type="bibl">
+     Санкт-Петербургские ведомости. 1863. № 145 от 28 июня.
+    </title>
+    <title level="m">
+     Санкт-Петербургские ведомости
+    </title>
+    <biblScope>
+     № 145 от 28 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1863
+     </date>
+    </imprint>
+   </item>
+   <item n="399" xml:id="Sankt_Peterburgskie_vedomosti_1873">
+    <title type="main">
+     Санкт-Петербургские ведомости. 1873. № 230 от 22 августа.
+    </title>
+    <title type="bibl">
+     Санкт-Петербургские ведомости. 1873. № 230 от 22 августа.
+    </title>
+    <title level="m">
+     Санкт-Петербургские ведомости
+    </title>
+    <biblScope>
+     № 230 от 22 августа
+    </biblScope>
+    <imprint>
+     <date>
+      1873
+     </date>
+    </imprint>
+   </item>
+   <item n="400" xml:id="Sbornik_materialov_dlja_opisanija_mestnostej_i_plemen_Kavkaza_1929">
+    <title type="main">
+     Сборник материалов для описания местностей и племен Кавказа. Вып. 46.
+    </title>
+    <title type="bibl">
+     Сборник материалов для описания местностей и племен Кавказа. Вып. 46. Махач-Кала, 1929.
+    </title>
+    <title level="a">
+     Сборник материалов для описания местностей и племен Кавказа
+    </title>
+    <biblScope>
+     Вып. 46
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Махач-Кала
+     </pubPlace>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="401" xml:id="Sbornik_Pushkinskogo_doma_na_1923_1922">
+    <title type="main">
+     Сборник Пушкинского дома на 1923.
+    </title>
+    <title type="bibl">
+     Сборник Пушкинского дома на 1923. Пд., 1922.
+    </title>
+    <title level="a">
+     Сборник Пушкинского дома на 1923
+    </title>
+    <imprint>
+     <pubPlace>
+      Пд.
+     </pubPlace>
+     <date>
+      1922
+     </date>
+    </imprint>
+   </item>
+   <item n="402" xml:id="Sbornik_svedenij_o_kavkazskih_gortsah_1868">
+    <title type="main">
+     Сборник сведений о кавказских горцах. Вып. 1.
+    </title>
+    <title type="bibl">
+     Сборник сведений о кавказских горцах. Вып. 1. Тифлис, 1868.
+    </title>
+    <title level="a">
+     Сборник сведений о кавказских горцах
+    </title>
+    <biblScope>
+     Вып. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Тифлис
+     </pubPlace>
+     <date>
+      1868
+     </date>
+    </imprint>
+   </item>
+   <item n="403" xml:id="Severnaja_pchela_1856">
+    <title type="main">
+     Северная пчела. 1856. № 222 от 9 октября.
+    </title>
+    <title type="bibl">
+     Северная пчела. 1856. № 222 от 9 октября.
+    </title>
+    <title level="a">
+     Северная пчела
+    </title>
+    <biblScope>
+     № 222 от 9 октября
+    </biblScope>
+    <imprint>
+     <date>
+      1856
+     </date>
+    </imprint>
+   </item>
+   <item n="404" xml:id="Semevskij_M_I_Pismo_k_Tolstomu_L_N_1889">
+    <title type="main">
+     Семевский М. И. Письмо к Толстому Л. Н.
+    </title>
+    <title type="bibl">
+     Семевский М. И. Письмо к Толстому Л. Н. // Русская старина. 1889. № 1.
+    </title>
+    <author>
+     Семевский М. И.
+    </author>
+    <title level="a">
+     Письмо к Толстому Л. Н.
+    </title>
+    <title level="m">
+     Русская старина
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1889
+     </date>
+    </imprint>
+   </item>
+   <item n="405" xml:id="Semevskij_M_N_Zametka_1880">
+    <title type="main">
+     Семевский М. Н. Заметка.
+    </title>
+    <title type="bibl">
+     Семевский М. Н. Заметка // Русская старина. 1880. № 4.
+    </title>
+    <author>
+     Семевский М. Н.
+    </author>
+    <title level="a">
+     Заметка
+    </title>
+    <title level="m">
+     Русская старина
+    </title>
+    <biblScope>
+     № 4
+    </biblScope>
+    <imprint>
+     <date>
+      1880
+     </date>
+    </imprint>
+   </item>
+   <item n="406" xml:id="Semenov_K_S_Istorija_lesov_za_sto_let_v_svjazi_s_dejatelnostju_i_znacheniem_L_N_Tolstogo">
+    <title type="main">
+     Семенов К. С. История лесов за сто лет в связи с деятельностью и значением Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Семенов К. С. История лесов за сто лет в связи с деятельностью и значением Л. Н. Толстого (музей-усадьба Ясная Поляна).
+    </title>
+    <author>
+     Семенов К. С.
+    </author>
+    <title level="a">
+     История лесов за сто лет в связи с деятельностью и значением Л. Н. Толстого
+    </title>
+    <repository>
+     Музей-усадьба Ясная Поляна
+    </repository>
+   </item>
+   <item n="407" xml:id="Semenov_K_S_Jasnaja_Poljana_Muzej_usadba_L_N_Tolstogo_Zapovednik_1950">
+    <title type="main">
+     Семенов К. С. Ясная Поляна. Музей-усадьба Л. Н. Толстого. Заповедник.
+    </title>
+    <title type="bibl">
+     Семенов К. С. Ясная Поляна. Музей-усадьба Л. Н. Толстого. Заповедник. Тула: Книжное изд-во, 1950.
+    </title>
+    <author>
+     Семенов К. С.
+    </author>
+    <title level="a">
+     Ясная Поляна. Музей-усадьба Л. Н. Толстого. Заповедник
+    </title>
+    <imprint>
+     <pubPlace>
+      Тула
+     </pubPlace>
+     <publisher>
+      Книжное изд-во
+     </publisher>
+     <date>
+      1950
+     </date>
+    </imprint>
+   </item>
+   <item n="408" xml:id="Semenov_S_T_Vospominanija_o_L_N_Tolstom_1912">
+    <title type="main">
+     Семенов С. Т. Воспоминания о Л. Н. Толстом.
+    </title>
+    <title type="bibl">
+     Семенов С. Т. Воспоминания о Л. Н. Толстом. СПб., 1912.
+    </title>
+    <author>
+     Семенов С. Т.
+    </author>
+    <title level="a">
+     Воспоминания о Л. Н. Толстом
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="409" xml:id="Semja_i_shkola_1874">
+    <title type="main">
+     Семья и школа. 1874. №№ 11–12.
+    </title>
+    <title type="bibl">
+     Семья и школа. 1874. №№ 11–12.
+    </title>
+    <title level="a">
+     Семья и школа
+    </title>
+    <biblScope>
+     №№ 11–12
+    </biblScope>
+    <imprint>
+     <date>
+      1874
+     </date>
+    </imprint>
+   </item>
+   <item n="410" xml:id="Sergeenko_P_A_Kak_zhivet_i_rabotaet_L_N_Tolstoj_1908">
+    <title type="main">
+     Сергеенко П. А. Как живет и работает Л. Н. Толстой.
+    </title>
+    <title type="bibl">
+     Сергеенко П. А. Как живет и работает Л. Н. Толстой. М., 1908.
+    </title>
+    <author>
+     Сергеенко П. А.
+    </author>
+    <title level="a">
+     Как живет и работает Л. Н. Толстой
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1908
+     </date>
+    </imprint>
+   </item>
+   <item n="411" xml:id="Sergeenko_P_A_Kommentarii_k_pismu_L_N_Tolstogo_1913">
+    <title type="main">
+     Сергеенко П. А. Комментарии к письму Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Сергеенко П. А. Комментарии к письму Л. Н. Толстого // Русское слово. 1913. № 20.
+    </title>
+    <author>
+     Сергеенко П. А.
+    </author>
+    <title level="a">
+     Комментарии к письму Л. Н. Толстого
+    </title>
+    <title level="m">
+     Русское слово
+    </title>
+    <biblScope>
+     № 20
+    </biblScope>
+    <imprint>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="412" xml:id="Sergeenko_P_A_Tolstoj_i_ego_sovremenniki_1911">
+    <title type="main">
+     Сергеенко П. А. Толстой и его современники.
+    </title>
+    <title type="bibl">
+     Сергеенко П. А. Толстой и его современники. М., 1911.
+    </title>
+    <author>
+     Сергеенко П. А.
+    </author>
+    <title level="a">
+     Толстой и его современники
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="413" xml:id="Tolstoj_o_literature_i_iskusstve_1939">
+    <title type="main">
+     Сергеенко П. А. Толстой о литературе и искусстве.
+    </title>
+    <title type="bibl">
+     Сергеенко П. А. Толстой о литературе и искусстве // Литературное наследство. № 37–38. М., 1939.
+    </title>
+    <title level="a">
+     Толстой о литературе и искусстве
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     № 37–38
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1939
+     </date>
+    </imprint>
+   </item>
+   <item n="414" xml:id="Seropolko_S_O_L_N_Tolstoj_i_ego_popytka_uchrezhdenija_v_Jasnoj_Poljane_pedagogicheskih_kursov_1910">
+    <title type="main">
+     Серополко С. О. Л. Н. Толстой и его попытка учреждения в Ясной Поляне педагогических курсов.
+    </title>
+    <title type="bibl">
+     Серополко С. О. Л. Н. Толстой и его попытка учреждения в Ясной Поляне педагогических курсов // Русские ведомости. 1910. 19 ноября.
+    </title>
+    <author>
+     Серополко С. О.
+    </author>
+    <title level="a">
+     Л. Н. Толстой и его попытка учреждения в Ясной Поляне педагогических курсов
+    </title>
+    <title level="m">
+     Русские ведомости
+    </title>
+    <imprint>
+     <date>
+      1910
+     </date>
+    </imprint>
+   </item>
+   <item n="415" xml:id="Skajler_E_Gr_L_N_Tolstoj_1890">
+    <title type="main">
+     Скайлер Е. Гр. Л. Н. Толстой.
+    </title>
+    <title type="bibl">
+     Скайлер Е. Гр. Л. Н. Толстой // Русская старина. 1890. № 10.
+    </title>
+    <author>
+     Скайлер Е.
+    </author>
+    <title level="a">
+     Гр. Л. Н. Толстой
+    </title>
+    <title level="m">
+     Русская старина
+    </title>
+    <biblScope>
+     № 10
+    </biblScope>
+    <imprint>
+     <date>
+      1890
+     </date>
+    </imprint>
+   </item>
+   <item n="416" xml:id="Skajler_E_Gr_L_N_Tolstoj_1890_b">
+    <title type="main">
+     Скайлер Е. Гр. Л. Н. Толстой.
+    </title>
+    <title type="bibl">
+     Скайлер Е. Гр. Л. Н. Толстой // Русская старина. 1890. № 9.
+    </title>
+    <author>
+     Скайлер Е.
+    </author>
+    <title level="a">
+     Гр. Л. Н. Толстой
+    </title>
+    <title level="m">
+     Русская старина
+    </title>
+    <biblScope>
+     № 9
+    </biblScope>
+    <imprint>
+     <date>
+      1890
+     </date>
+    </imprint>
+   </item>
+   <item n="417" xml:id="Sovremennik_1855">
+    <title type="main">
+     Современник. 1855. № 12.
+    </title>
+    <title type="bibl">
+     Современник. 1855. № 12.
+    </title>
+    <title level="m">
+     Современник
+    </title>
+    <biblScope>
+     № 12
+    </biblScope>
+    <imprint>
+     <date>
+      1855
+     </date>
+    </imprint>
+   </item>
+   <item n="418" xml:id="Soobschenie_1885">
+    <title type="main">
+     Сообщение. — «Общее дело» 1885, № 73.
+    </title>
+    <title type="bibl">
+     Сообщение // Общее дело. 1885. № 73.
+    </title>
+    <title level="a">
+     Сообщение
+    </title>
+    <title level="m">
+     Общее дело
+    </title>
+    <biblScope>
+     № 73
+    </biblScope>
+    <imprint>
+     <date>
+      1885
+     </date>
+    </imprint>
+   </item>
+   <item n="419" xml:id="Soobschenie_o_lektsii_V_S_Soloveva_1878">
+    <title type="main">
+     Сообщение о лекции В. С. Соловьева.
+    </title>
+    <title type="bibl">
+     Сообщение о лекции В. С. Соловьева // Голос. 1878. № 71 от 12 марта.
+    </title>
+    <title level="a">
+     Сообщение о лекции В. С. Соловьева
+    </title>
+    <title level="m">
+     Голос
+    </title>
+    <biblScope>
+     № 71 от 12 марта
+    </biblScope>
+    <imprint>
+     <date>
+      1878
+     </date>
+    </imprint>
+   </item>
+   <item n="420" xml:id="Spiridonov_V_S_K_istorii_pedagogicheskoj_dejatelnosti_L_N_Tolstogo_1948">
+    <title type="main">
+     Спиридонов В. С. К истории педагогической деятельности Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Спиридонов В. С. К истории педагогической деятельности Л. Н. Толстого // Ученые записки Ленинградского Педагогического института. Т. 67. Л., 1948.
+    </title>
+    <author>
+     Спиридонов В. С.
+    </author>
+    <title level="a">
+     К истории педагогической деятельности Л. Н. Толстого
+    </title>
+    <title level="m">
+     Ученые записки Ленинградского Педагогического института
+    </title>
+    <biblScope>
+     Т. 67
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Л.
+     </pubPlace>
+     <date>
+      1948
+     </date>
+    </imprint>
+   </item>
+   <item n="421" xml:id="Spiridonov_V_S_L_N_Tolstoj_pedagog_na_sude_tsenzury_i_kritiki_shestidesjatyh_godov_1940">
+    <title type="main">
+     Спиридонов В. С. Л. Н. Толстой педагог на суде цензуры и критики шестидесятых годов.
+    </title>
+    <title type="bibl">
+     Спиридонов В. С. Л. Н. Толстой педагог на суде цензуры и критики шестидесятых годов // Ученые записки Ленинградского Педагогического института. Т. 4. Вып. 2. Л., 1940.
+    </title>
+    <author>
+     Спиридонов В. С.
+    </author>
+    <title level="a">
+     Л. Н. Толстой педагог на суде цензуры и критики шестидесятых годов
+    </title>
+    <title level="m">
+     Ученые записки Ленинградского Педагогического института
+    </title>
+    <biblScope>
+     Т. 4, Вып. 2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Л.
+     </pubPlace>
+     <date>
+      1940
+     </date>
+    </imprint>
+   </item>
+   <item n="422" xml:id="Spiridonov_V_S_L_N_Tolstoj_Bio_bibliografija_1845_1870_1933">
+    <title type="main">
+     Спиридонов В. С. Л. Н. Толстой. Био-библиография. 1845–1870.
+    </title>
+    <title type="bibl">
+     Спиридонов В. С. Л. Н. Толстой. Био-библиография. 1845–1870. М.: Academia, 1933.
+    </title>
+    <author>
+     Спиридонов В. С.
+    </author>
+    <title level="a">
+     Л. Н. Толстой. Био-библиография. 1845–1870
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Academia
+     </publisher>
+     <date>
+      1933
+     </date>
+    </imprint>
+   </item>
+   <item n="423" xml:id="Sreznevskij_I_I_O_L_N_Tolstom_1922">
+    <title type="main">
+     Срезневский И. И. О Л. Н. Толстом.
+    </title>
+    <title type="bibl">
+     Срезневский И. И. О Л. Н. Толстом // Сборник в честь А. И. Соболевского. Пд., 1922.
+    </title>
+    <author>
+     Срезневский И. И.
+    </author>
+    <title level="a">
+     О Л. Н. Толстом
+    </title>
+    <title level="m">
+     Сборник в честь А. И. Соболевского
+    </title>
+    <imprint>
+     <pubPlace>
+      Пд.
+     </pubPlace>
+     <date>
+      1922
+     </date>
+    </imprint>
+   </item>
+   <item n="424" xml:id="Stasov_Vladimir_Vasilevich_N_N_Ge_ego_zhizn_proizvedenija_i_perepiska_1904">
+    <title type="main">
+     Стасов В. В. Н. Н. Ге, его жизнь, произведения и переписка.
+    </title>
+    <title type="bibl">
+     Стасов В. В. Н. Н. Ге, его жизнь, произведения и переписка. М.: «Посредник», 1904.
+    </title>
+    <author>
+     Стасов Владимир Васильевич
+    </author>
+    <title level="a">
+     Н. Н. Ге, его жизнь, произведения и переписка
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      «Посредник»
+     </publisher>
+     <date>
+      1904
+     </date>
+    </imprint>
+   </item>
+   <item n="425" xml:id="Stasjulevich_M_M_M_M_Stasjulevich_i_ego_sovremenniki_v_ih_perepiske_1912">
+    <title type="main">
+     Стасюлевич М. М. и его современники в их переписке. Т. 3.
+    </title>
+    <title type="bibl">
+     Стасюлевич М. М. и его современники в их переписке. Т. 3. СПб., 1912.
+    </title>
+    <author>
+     Стасюлевич М. М.
+    </author>
+    <title level="a">
+     М. М. Стасюлевич и его современники в их переписке
+    </title>
+    <biblScope>
+     Т. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="426" xml:id="Stahovich_A_A_Klochki_vospominanij_1912">
+    <title type="main">
+     Стахович А. А. Клочки воспоминаний.
+    </title>
+    <title type="bibl">
+     Стахович А. А. Клочки воспоминаний // Толстовский ежегодник 1912 г. 1912.
+    </title>
+    <author>
+     Стахович А. А.
+    </author>
+    <title level="a">
+     Клочки воспоминаний
+    </title>
+    <title level="m">
+     Толстовский ежегодник 1912 г.
+    </title>
+    <imprint>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="427" xml:id="Stahovich_A_A_Pismo_k_Tolstoj_S_A_1912">
+    <title type="main">
+     Стахович А. А. Письмо к Толстой С. А.
+    </title>
+    <title type="bibl">
+     Стахович А. А. Письмо к Толстой С. А. // Толстовский ежегодник 1912 г. М., 1912.
+    </title>
+    <author>
+     Стахович А. А.
+    </author>
+    <title level="a">
+     Письмо к Толстой С. А.
+    </title>
+    <title level="m">
+     Толстовский ежегодник 1912 г.
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="428" xml:id="Stechkin_N_Ja_Iz_vospominanij_ob_I_S_Turgeneve_1903">
+    <title type="main">
+     Стечькин Н. Я. Из воспоминаний об И. С. Тургеневе.
+    </title>
+    <title type="bibl">
+     Стечькин Н. Я. Из воспоминаний об И. С. Тургеневе. СПб., 1903.
+    </title>
+    <author>
+     Стечькин Н. Я.
+    </author>
+    <title level="a">
+     Из воспоминаний об И. С. Тургеневе
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1903
+     </date>
+    </imprint>
+   </item>
+   <item n="429" xml:id="Storozhenko_N_I_Pismo_k_Semevskomu_V_I_1918">
+    <title type="main">
+     Стороженко Н. И. Письмо к Семевскому В. И.
+    </title>
+    <title type="bibl">
+     Стороженко Н. И. Письмо к Семевскому В. И. // Голос минувшего. 1918. №№ 4–6.
+    </title>
+    <author>
+     Стороженко Н. И.
+    </author>
+    <title level="a">
+     Письмо к Семевскому В. И.
+    </title>
+    <title level="m">
+     Голос минувшего
+    </title>
+    <biblScope>
+     №№ 4–6
+    </biblScope>
+    <imprint>
+     <date>
+      1918
+     </date>
+    </imprint>
+   </item>
+   <item n="430" xml:id="Strahov_Nikolaj_Nikolaevich_Pismo_k_Danilevskomu_N_Ja_1901">
+    <title type="main">
+     Страхов Н. Н.  Письмо к Данилевскому Н. Я.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н.  Письмо к Данилевскому Н. Я. // Русский вестник. 1901. № 3.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Письмо к Данилевскому Н. Я.
+    </title>
+    <title level="m">
+     Русский вестник
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1901
+     </date>
+    </imprint>
+   </item>
+   <item n="431" xml:id="Strahov_Nikolaj_Nikolaevich_Dnevnikovye_zametki">
+    <title type="main">
+     Страхов Н. Н. Дневниковые заметки.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Дневниковые заметки (Институт русской литературы РАН (Пушкинский Дом)).
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Дневниковые заметки
+    </title>
+    <repository>
+     Институт русской литературы РАН (Пушкинский Дом)
+    </repository>
+   </item>
+   <item n="432" xml:id="Strahov_Nikolaj_Nikolaevich_Zakonomernost_stihij_i_ponjatij_1885">
+    <title type="main">
+     Страхов Н. Н. Закономерность стихий и понятий.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Закономерность стихий и понятий // Новое время. 1885. № 3487.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Закономерность стихий и понятий
+    </title>
+    <title level="m">
+     Новое время
+    </title>
+    <biblScope>
+     № 3487
+    </biblScope>
+    <imprint>
+     <date>
+      1885
+     </date>
+    </imprint>
+   </item>
+   <item n="433" xml:id="Strahov_Nikolaj_Nikolaevich_Zakonomernost_stihij_i_ponjatij_1885_b">
+    <title type="main">
+     Страхов Н. Н. Закономерность стихий и понятий.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Закономерность стихий и понятий // Новое время. 1885. № 3502.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Закономерность стихий и понятий
+    </title>
+    <title level="m">
+     Новое время
+    </title>
+    <biblScope>
+     № 3502
+    </biblScope>
+    <imprint>
+     <date>
+      1885
+     </date>
+    </imprint>
+   </item>
+   <item n="434" xml:id="Strahov_Nikolaj_Nikolaevich_Kritika_Vojna_i_mir_Soch_gr_L_N_Tolstogo_1869">
+    <title type="main">
+     Страхов Н. Н. Критика. «Война и мир». Соч. гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Критика. «Война и мир». Соч. гр. Л. Н. Толстого // Заря. 1869. № 1.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Критика. «Война и мир». Соч. гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Заря
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1869
+     </date>
+    </imprint>
+   </item>
+   <item n="435" xml:id="Strahov_Nikolaj_Nikolaevich_Kritika_Vojna_i_mir_Soch_gr_L_N_Tolstogo_1869_b">
+    <title type="main">
+     Страхов Н. Н. Критика. «Война и мир». Соч. гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Критика. «Война и мир». Соч. гр. Л. Н. Толстого // Заря. 1869. № 2.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Критика. «Война и мир». Соч. гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Заря
+    </title>
+    <biblScope>
+     № 2
+    </biblScope>
+    <imprint>
+     <date>
+      1869
+     </date>
+    </imprint>
+   </item>
+   <item n="436" xml:id="Strahov_Nikolaj_Nikolaevich_Kritika_Vojna_i_mir_Soch_gr_L_N_Tolstogo_1870">
+    <title type="main">
+     Страхов Н. Н. Критика. «Война и мир». Соч. гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Критика. «Война и мир». Соч. гр. Л. Н. Толстого // Заря. 1870. № 1.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Критика. «Война и мир». Соч. гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Заря
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1870
+     </date>
+    </imprint>
+   </item>
+   <item n="437" xml:id="Strahov_Nikolaj_Nikolaevich_Pismo_k_Golohvastovu_P_D_1936">
+    <title type="main">
+     Страхов Н. Н. Письмо к Голохвастову П. Д.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Письмо к Голохвастову П. Д. // Толстой Л. Н. Полное собрание сочинений. Юбилейное издание. Т. 17. 1936.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Письмо к Голохвастову П. Д.
+    </title>
+    <title level="m">
+     Толстой Л. Н. Полное собрание сочинений. Юбилейное издание
+    </title>
+    <biblScope>
+     Т. 17
+    </biblScope>
+    <imprint>
+     <date>
+      1936
+     </date>
+    </imprint>
+   </item>
+   <item n="438" xml:id="Strahov_Nikolaj_Nikolaevich_Pismo_k_Danilevskomu_N_Ja_1901_b">
+    <title type="main">
+     Страхов Н. Н. Письмо к Данилевскому Н. Я.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Письмо к Данилевскому Н. Я. // Русский вестник. 1901. № 1.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Письмо к Данилевскому Н. Я.
+    </title>
+    <title level="m">
+     Русский вестник
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1901
+     </date>
+    </imprint>
+   </item>
+   <item n="439" xml:id="Strahov_Nikolaj_Nikolaevich_Pismo_k_Fetu_A_A_1901">
+    <title type="main">
+     Страхов Н. Н. Письмо к Фету А. А.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Письмо к Фету А. А. // Русское обозрение. 1901. № 1.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Письмо к Фету А. А.
+    </title>
+    <title level="m">
+     Русское обозрение
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1901
+     </date>
+    </imprint>
+   </item>
+   <item n="440" xml:id="Strahov_Nikolaj_Nikolaevich_Pushkinskij_prazdnik_Zametki_o_Pushkine_i_drugih_poetah_1888">
+    <title type="main">
+     Страхов Н. Н. Пушкинский праздник. Заметки о Пушкине и других поэтах.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Пушкинский праздник. Заметки о Пушкине и других поэтах. СПб., 1888.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Пушкинский праздник. Заметки о Пушкине и других поэтах
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1888
+     </date>
+    </imprint>
+   </item>
+   <item n="441" xml:id="Strahov_Nikolaj_Nikolaevich_Tri_pisma_o_spiritizme_1876">
+    <title type="main">
+     Страхов Н. Н. Три письма о спиритизме.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Три письма о спиритизме // Гражданин. 1876. № 41.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Три письма о спиритизме
+    </title>
+    <title level="m">
+     Гражданин
+    </title>
+    <biblScope>
+     № 41
+    </biblScope>
+    <imprint>
+     <date>
+      1876
+     </date>
+    </imprint>
+   </item>
+   <item n="442" xml:id="Strahov_Nikolaj_Nikolaevich_Tri_pisma_o_spiritizme_1876_b">
+    <title type="main">
+     Страхов Н. Н. Три письма о спиритизме.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Три письма о спиритизме // Гражданин. 1876. № 42.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Три письма о спиритизме
+    </title>
+    <title level="m">
+     Гражданин
+    </title>
+    <biblScope>
+     № 42
+    </biblScope>
+    <imprint>
+     <date>
+      1876
+     </date>
+    </imprint>
+   </item>
+   <item n="443" xml:id="Strahov_Nikolaj_Nikolaevich_Tri_pisma_o_spiritizme_1876_c">
+    <title type="main">
+     Страхов Н. Н. Три письма о спиритизме.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Три письма о спиритизме // Гражданин. 1876. № 43.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Три письма о спиритизме
+    </title>
+    <title level="m">
+     Гражданин
+    </title>
+    <biblScope>
+     № 43
+    </biblScope>
+    <imprint>
+     <date>
+      1876
+     </date>
+    </imprint>
+   </item>
+   <item n="444" xml:id="Strahov_Nikolaj_Nikolaevich_Tri_pisma_o_spiritizme_1876_d">
+    <title type="main">
+     Страхов Н. Н. Три письма о спиритизме.
+    </title>
+    <title type="bibl">
+     Страхов Н. Н. Три письма о спиритизме // Гражданин. 1876. № 44.
+    </title>
+    <author>
+     Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Три письма о спиритизме
+    </title>
+    <title level="m">
+     Гражданин
+    </title>
+    <biblScope>
+     № 44
+    </biblScope>
+    <imprint>
+     <date>
+      1876
+     </date>
+    </imprint>
+   </item>
+   <item n="445" xml:id="Surikov_Vasilij_Ivanovich_Pisma_1868_1916_1948">
+    <title type="main">
+     Суриков В. И. Письма. 1868–1916.
+    </title>
+    <title type="bibl">
+     Суриков В. И. Письма. 1868–1916. М.–Л.: «Искусство», 1948.
+    </title>
+    <author>
+     Суриков Василий Иванович
+    </author>
+    <title level="a">
+     Письма. 1868–1916
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      «Искусство»
+     </publisher>
+     <date>
+      1948
+     </date>
+    </imprint>
+   </item>
+   <item n="446" xml:id="Suhotina_Tolstaja_Tatjana_Lvovna_I_S_Turgenev_1923">
+    <title type="main">
+     Сухотина-Толстая Т. Л. И. С. Тургенев.
+    </title>
+    <title type="bibl">
+     Сухотина-Толстая Т. Л. И. С. Тургенев // Сухотина-Толстая Т. Л. Друзья и гости Ясной Поляны. М., 1923.
+    </title>
+    <author>
+     Сухотина-Толстая Татьяна Львовна
+    </author>
+    <title level="a">
+     И. С. Тургенев
+    </title>
+    <title level="m">
+     Сухотина-Толстая Т. Л. Друзья и гости Ясной Поляны
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="447" xml:id="Syn_otechestva_1856">
+    <title type="main">
+     Сын отечества. 1856. № 18 от 5 августа.
+    </title>
+    <title type="bibl">
+     Сын отечества. 1856. № 18 от 5 августа.
+    </title>
+    <title level="m">
+     Сын отечества
+    </title>
+    <biblScope>
+     № 18 от 5 августа
+    </biblScope>
+    <imprint>
+     <date>
+      1856
+     </date>
+    </imprint>
+   </item>
+   <item n="448" xml:id="Sytin_I_D_Iz_perezhitogo_Avtobiograficheskie_nabroski_1916">
+    <title type="main">
+     Сытин И. Д. Из пережитого. Автобиографические наброски.
+    </title>
+    <title type="bibl">
+     Сытин И. Д. Из пережитого. Автобиографические наброски. // Полвека для книги. Литературно-художественный сборник, посвященный пятидесятилетию издательской деятельности И. Д. Сытина. М., 1916.
+    </title>
+    <author>
+     Сытин И. Д.
+    </author>
+    <title level="a">
+     Из пережитого. Автобиографические наброски
+    </title>
+    <title level="m">
+     Полвека для книги. Литературно-художественный сборник, посвященный пятидесятилетию издательской деятельности И. Д. Сытина
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1916
+     </date>
+    </imprint>
+   </item>
+   <item n="449" xml:id="Tajnye_obschestva_v_Rossii_v_nachale_XIX_stoletija_1926">
+    <title type="main">
+     Тайные общества в России в начале XIX столетия. Сборник материалов, статей и воспоминаний.
+    </title>
+    <title type="bibl">
+     Тайные общества в России в начале XIX столетия. Сборник материалов, статей и воспоминаний. М., 1926.
+    </title>
+    <title level="a">
+     Тайные общества в России в начале XIX столетия
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1926
+     </date>
+    </imprint>
+   </item>
+   <item n="450" xml:id="Taliashvili_G_Lev_Tolstoj_i_Gruzija_1951">
+    <title type="main">
+     Талиашвили Г. Лев Толстой и Грузия.
+    </title>
+    <title type="bibl">
+     Талиашвили Г. Лев Толстой и Грузия. Тбилиси: изд. «Заря Востока», 1951.
+    </title>
+    <author>
+     Талиашвили Г.
+    </author>
+    <title level="a">
+     Лев Толстой и Грузия
+    </title>
+    <imprint>
+     <pubPlace>
+      Тбилиси
+     </pubPlace>
+     <publisher>
+      изд. «Заря Востока»
+     </publisher>
+     <date>
+      1951
+     </date>
+    </imprint>
+   </item>
+   <item n="451" xml:id="Tihomirov_D_I_Iz_vospominanij_o_L_N_Tolstom_1910">
+    <title type="main">
+     Тихомиров Д. И. Из воспоминаний о Л. Н. Толстом.
+    </title>
+    <title type="bibl">
+     Тихомиров Д. И. Из воспоминаний о Л. Н. Толстом // Педагогический листок. 1910. № 8.
+    </title>
+    <author>
+     Тихомиров Д. И.
+    </author>
+    <title level="a">
+     Из воспоминаний о Л. Н. Толстом
+    </title>
+    <title level="m">
+     Педагогический листок
+    </title>
+    <biblScope>
+     № 8
+    </biblScope>
+    <imprint>
+     <date>
+      1910
+     </date>
+    </imprint>
+   </item>
+   <item n="452" xml:id="Tihotskij_V_A_Pismo_k_Mishinu_V_S_1934">
+    <title type="main">
+     Тихоцкий В. А. Письмо к Мишину В. С.
+    </title>
+    <title type="bibl">
+     Тихоцкий В. А. Письмо к Мишину В. С. // Толстой Л. Н. Полное собрание сочинений. Т. 63. 1934.
+    </title>
+    <author>
+     Тихоцкий В. А.
+    </author>
+    <title level="a">
+     Письмо к Мишину В. С.
+    </title>
+    <title level="m">
+     Толстой Л. Н. Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 63
+    </biblScope>
+    <imprint>
+     <date>
+      1934
+     </date>
+    </imprint>
+   </item>
+   <item n="453" xml:id="Tolstaja_Aleksandra_Andreevna_Vospominanija_1911">
+    <title type="main">
+     Толстая А. А. Воспоминания.
+    </title>
+    <title type="bibl">
+     Толстая А. А. Воспоминания // Толстой Л. H. и Толстая А. А. Переписка. СПб.: Изд. Общества Толстовского музея, 1911.
+    </title>
+    <author>
+     Толстая Александра Андреевна
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Толстой Л. H. и Толстая А. А. Переписка
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <publisher>
+      Изд. Общества Толстовского музея
+     </publisher>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="454" xml:id="Tolstaja_Aleksandra_Andreevna_Dnevnik">
+    <title type="main">
+     Толстая А. А. Дневник.
+    </title>
+    <title type="bibl">
+     Толстая А. А. Дневник (Центральный государственный архив литературы и искусства в Москве).
+    </title>
+    <author>
+     Толстая Александра Андреевна
+    </author>
+    <title level="a">
+     Дневник
+    </title>
+    <repository>
+     Центральный государственный архив литературы и искусства
+    </repository>
+   </item>
+   <item n="455" xml:id="Tolstaja_Marija_Lvovna_Pismo_k_Solovevu_A_T_1912">
+    <title type="main">
+     Толстая М. Л. Письмо к Соловьеву А. Т.
+    </title>
+    <title type="bibl">
+     Толстая М. Л. Письмо к Соловьеву А. Т. // Толстовский ежегодник 1912 г. М., 1912.
+    </title>
+    <author>
+     Толстая Мария Львовна
+    </author>
+    <title level="a">
+     Письмо к Соловьеву А. Т.
+    </title>
+    <title level="m">
+     Толстовский ежегодник 1912 г.
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="456" xml:id="Tolstaja_Sofja_Andreevna_Vospominanija_1912">
+    <title type="main">
+     Толстая С. А. Воспоминания.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Воспоминания // Толстовский ежегодник. 1912 г. 1912.
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Толстовский ежегодник 1912 г.
+    </title>
+    <imprint>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="457" xml:id="Tolstaja_Sofja_Andreevna_Vospominanija_ob_I_S_Turgeneve_1903">
+    <title type="main">
+     Толстая С. А. Воспоминания об И. С. Тургеневе.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Воспоминания об И. С. Тургеневе // Орловский вестник. 1903. № 224.
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <title level="a">
+     Воспоминания об И. С. Тургеневе
+    </title>
+    <title level="m">
+     Орловский вестник
+    </title>
+    <biblScope>
+     № 224
+    </biblScope>
+    <imprint>
+     <date>
+      1903
+     </date>
+    </imprint>
+   </item>
+   <item n="458" xml:id="Tolstaja_Sofja_Andreevna_Dnevniki_1860_1891_1928">
+    <title type="main">
+     Толстая С. А. Дневники 1860–1891.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Дневники 1860–1891. / Ред. С. Л. Толстого. Примеч. С. Л. Толстого и Г. А. Волкова. Предисл. М. А. Цявловского. М.: Изд. М. и С. Сабашниковых, 1928.
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <editor>
+     Толстой Сергей Львович
+    </editor>
+    <title level="a">
+     Дневники 1860–1891
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. М. и С. Сабашниковых
+     </publisher>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="459" xml:id="Tolstaja_Sofja_Andreevna_Dnevniki_1891_1897_1928">
+    <title type="main">
+     Толстая С. А. Дневники 1891–1897.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Дневники 1891–1897. / Ред. С. Л. Толстого. Примеч. С. Л. Толстого и Г. А. Волкова. Предисл. М. А. Цявловского. М.: Изд. М. и С. Сабашниковых, 1929.
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <editor>
+     Толстой Сергей Львович
+    </editor>
+    <title level="a">
+     Дневники 1891–1897
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. М. и С. Сабашниковых
+     </publisher>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="460" xml:id="Tolstaja_Sofja_Andreevna_Dnevniki_1897_1909_1929">
+    <title type="main">
+     Толстая С. А. Дневники 1897–1909.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Дневники 1897–1909. / Ред. и предисл. С. Л. Толстого. Примеч. С. Л. Толстого и Г. А. Волкова. М.: Изд-во «Север», 1932.
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <editor>
+     Толстой Сергей Львович
+    </editor>
+    <title level="a">
+     Дневники 1897–1909
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд-во «Север»
+     </publisher>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="461" xml:id="Tolstaja_Sofja_Andreevna_Dnevniki_1910_1932">
+    <title type="main">
+     Толстая С. А. Дневники 1910.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Дневники 1910. / Ред. и предисл. С. Л. Толстого. Примеч. С. Л. Толстого и Г. А. Волкова. М.: «Сов. писатель», 1936.
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <editor>
+     Толстой Сергей Львович
+    </editor>
+    <title level="a">
+     Дневники 1910
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      «Сов. писатель»
+     </publisher>
+     <date>
+      1932
+     </date>
+    </imprint>
+   </item>
+   <item n="462" xml:id="Tolstaja_Sofja_Andreevna_Kratkij_biograficheskij_ocherk_L_N_Tolstogo_sostavlennyj_ego_zhenoj_v_1878_g_1936">
+    <title type="main">
+     Толстая С. А. Краткий биографический очерк Л. Н. Толстого, составленный его женой в 1878 г.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Краткий биографический очерк Л. Н. Толстого, составленный его женой в 1878 г. (Государственный музей Л. Н. Толстого в Москве)
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <title level="a">
+     Краткий биографический очерк Л. Н. Толстого, составленный его женой в 1878 г.
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+    <imprint>
+     <date>
+      1936
+     </date>
+    </imprint>
+   </item>
+   <item n="463" xml:id="Tolstaja_Sofja_Andreevna_Moja_zhizn">
+    <title type="main">
+     Толстая С. А. Моя жизнь.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Моя жизнь (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <title level="a">
+     Моя жизнь
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+   </item>
+   <item n="464" xml:id="Tolstaja_Sofja_Andreevna_Pervoe_predstavlenie_komedii_L_N_Tolstogo_Plody_prosveschenija_1912">
+    <title type="main">
+     Толстая С. А. Первое представление комедии Л. Н. Толстого «Плоды просвещения».
+    </title>
+    <title type="bibl">
+     Толстая С. А. Первое представление комедии Л. Н. Толстого «Плоды просвещения» // Солнце России. 1912. № 145 от 7 ноября.
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <title level="a">
+     Первое представление комедии Л. Н. Толстого «Плоды просвещения»
+    </title>
+    <title level="m">
+     Солнце России
+    </title>
+    <biblScope>
+     № 145 от 7 ноября
+    </biblScope>
+    <imprint>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="465" xml:id="Tolstaja_Sofja_Andreevna_Pisma_k_L_N_Tolstomu_1936">
+    <title type="main">
+     Толстая С. А. Письма к Л. Н. Толстому.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Письма к Л. Н. Толстому. М.: Academia, 1936.
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <title level="a">
+     Письма к Л. Н. Толстому
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1936
+     </date>
+    </imprint>
+   </item>
+   <item n="466" xml:id="Tolstaja_Sofja_Andreevna_Pismo_k_Islavinu_K_A_1924">
+    <title type="main">
+     Толстая С. А. Письмо к Иславину К. А.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Письмо к Иславину К. А. // Красный архив. 1924. № 7.
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <title level="a">
+     Письмо к Иславину К. А.
+    </title>
+    <title level="m">
+     Красный архив
+    </title>
+    <biblScope>
+     № 7
+    </biblScope>
+    <imprint>
+     <date>
+      1924
+     </date>
+    </imprint>
+   </item>
+   <item n="467" xml:id="Tolstaja_Sofja_Andreevna_Primirenie_gr_L_N_Tolstogo_s_I_S_Turgenevym_1928">
+    <title type="main">
+     Толстая С. А. Примирение гр. Л. Н. Толстого с И. С. Тургеневым.
+    </title>
+    <title type="bibl">
+     Толстая С. А. Примирение гр. Л. Н. Толстого с И. С. Тургеневым // Толстая С. А. Дневники. Ч. 1. М., 1928.
+    </title>
+    <author>
+     Толстая Софья Андреевна
+    </author>
+    <title level="a">
+     Примирение гр. Л. Н. Толстого с И. С. Тургеневым
+    </title>
+    <title level="m">
+     Толстая С. А. Дневники
+    </title>
+    <biblScope>
+     Ч. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="468" xml:id="Tolstaja_Suhotina_Tatjana_Lvovna_Detstvo_Tani_Tolstoj_1928">
+    <title type="main">
+     Толстая-Сухотина Т. Л. Детство Тани Толстой.
+    </title>
+    <title type="bibl">
+     Толстая-Сухотина Т. Л. Детство Тани Толстой (Государственный музей Л. Н. Толстого в Москве).
+    </title>
+    <author>
+     Толстая-Сухотина Татьяна Львовна
+    </author>
+    <title level="a">
+     Детство Тани Толстой
+    </title>
+    <repository>
+     Государственный музей Л. Н. Толстого
+    </repository>
+    <imprint>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="469" xml:id="Tolstovskij_ezhegodnik_1912_g_1912">
+    <title type="main">
+     Толстовский ежегодник 1912 г.
+    </title>
+    <title type="bibl">
+     Толстовский ежегодник 1912 г. М.: Изд. об-ва Толстовского музея в Петербурге и Толстовского об-ва в Москве, 1912.
+    </title>
+    <title level="a">
+     Толстовский ежегодник 1912 г.
+    </title>
+    <biblScope>
+     Толстовский ежегодник 1912 г.
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. об-ва Толстовского музея в Петербурге и Толстовского об-ва в Москве
+     </publisher>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="470" xml:id="Tolstovskij_ezhegodnik_1913_g_1914">
+    <title type="main">
+     Толстовский ежегодник 1913 г.
+    </title>
+    <title type="bibl">
+     Толстовский ежегодник 1913 г. Изд. об-ва Толстовского музея в С.-Петербурге и Толстовского об-ва в Москве, 1914.
+    </title>
+    <title level="a">
+     Толстовский ежегодник 1913 г.
+    </title>
+    <biblScope>
+     Толстовский ежегодник 1913 г.
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. об-ва Толстовского музея в Петербурге и Толстовского об-ва в Москве
+     </publisher>
+     <date>
+      1914
+     </date>
+    </imprint>
+   </item>
+   <item n="471" xml:id="Polnoe_sobranie_sochinenij_1908">
+    <title type="main">
+     Толстой А. К. Полное собрание сочинений. Т. 4.
+    </title>
+    <title type="bibl">
+     Толстой А. К. Полное собрание сочинений. Т. 4. СПб., 1908.
+    </title>
+    <title level="a">
+     Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 4
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1908
+     </date>
+    </imprint>
+   </item>
+   <item n="472" xml:id="Tolstoj_i_o_Tolstom_Novye_materialy_1927">
+    <title type="main">
+     Толстой и о Толстом. Новые материалы.
+    </title>
+    <title type="bibl">
+     Толстой и о Толстом. Новые материалы. / Ред.Н. Н. Гусева. М.: Изд. Толстовского музея, 1927.
+    </title>
+    <title level="a">
+     Толстой и о Толстом. Новые материалы
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. Толстовского музея
+     </publisher>
+     <date>
+      1927
+     </date>
+    </imprint>
+   </item>
+   <item n="473" xml:id="Tolstoj_i_o_Tolstom_Novye_materialy_Sb_3_1927">
+    <title type="main">
+     Толстой и о Толстом. Новые материалы. Сб. 3.
+    </title>
+    <title type="bibl">
+     Толстой и о Толстом. Новые материалы. Сб. 3. / Ред. Н. Н. Гусева и В. Г. Черткова. М.: Изд. Толстовского музея, 1927.
+    </title>
+    <editor>
+     Гусев Николай Николаевич и Чертков Владимир Григорьевич
+    </editor>
+    <title level="a">
+     Толстой и о Толстом. Новые материалы. Сб. 3
+    </title>
+    <biblScope>
+     Сб. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. Толстовского музея
+     </publisher>
+     <date>
+      1927
+     </date>
+    </imprint>
+   </item>
+   <item n="474" xml:id="Tolstoj_Ilja_Lvovich_Moi_vospominanija_1933">
+    <title type="main">
+     Толстой И. Л. Мои воспоминания.
+    </title>
+    <title type="bibl">
+     Толстой И. Л. Мои воспоминания. М.: Изд. «Мир», 1933.
+    </title>
+    <author>
+     Толстой Илья Львович
+    </author>
+    <title level="a">
+     Мои воспоминания
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. «Мир»
+     </publisher>
+     <date>
+      1933
+     </date>
+    </imprint>
+   </item>
+   <item n="475" xml:id="Tolstoj_Lev_Lvovich_V_Jasnoj_Poljane_1923">
+    <title type="main">
+     Толстой Л. Л. В Ясной Поляне.
+    </title>
+    <title type="bibl">
+     Толстой Л. Л. В Ясной Поляне. Прага, 1923.
+    </title>
+    <author>
+     Толстой Лев Львович
+    </author>
+    <title level="a">
+     В Ясной Поляне
+    </title>
+    <imprint>
+     <pubPlace>
+      Прага
+     </pubPlace>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="476" xml:id="Tolstoj_Lev_Nikolaevich_Strahov_Nikolaj_Nikolaevich_Perepiska_1914">
+    <title type="main">
+     Толстой Л. Н. и Страхов Н. Н. Переписка.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. и Страхов Н. Н. Переписка. / Предисловие и примечания Б. Л. Модзалевского. СПб.: Изд. Общества Толстовского музея, 1914.
+    </title>
+    <author>
+     Толстой Лев Николаевич, Страхов Николай Николаевич
+    </author>
+    <title level="a">
+     Переписка
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <publisher>
+      Изд. Общества Толстовского музея
+     </publisher>
+     <date>
+      1914
+     </date>
+    </imprint>
+   </item>
+   <item n="477" xml:id="Tolstoj_Lev_Nikolaevich_Tolstaja_Anna_Andreevna_Perepiska_1911">
+    <title type="main">
+     Толстой Л. Н. и Толстая  А. А. Переписка.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. и Толстая  А. А. Переписка. СПб.: Изд. Общества Толстовского музея в Петербурге, 1911.
+    </title>
+    <author>
+     Толстой Лев Николаевич, Толстая Анна Андреевна
+    </author>
+    <title level="a">
+     Переписка
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <publisher>
+      Изд. Общества Толстовского музея в Петербурге
+     </publisher>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="478" xml:id="Tolstoj_Lev_Nikolaevich_Turgenev_Ivan_Sergeevich_Perepiska_1928">
+    <title type="main">
+     Толстой Л. Н. и Тургенев И. С. Переписка.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. и Тургенев И. С. Переписка. / Ред. и примечания А. Е. Грузинского и М. А. Цявловского. М.: Изд. М. и С. Сабашниковых, 1928.
+    </title>
+    <author>
+     Толстой Лев Николаевич, Тургенев Иван Сергеевич
+    </author>
+    <editor>
+     Грузинский А. Е. и Цявловский М. А.
+    </editor>
+    <title level="a">
+     Переписка
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. М. и С. Сабашниковых
+     </publisher>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="479" xml:id="Tolstoj_Lev_Nikolaevich_Izbrannye_proizvedenija_1927">
+    <title type="main">
+     Толстой Л. Н. Избранные произведения.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. Избранные произведения. М.: ГИЗ, 1927.
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Избранные произведения
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      ГИЗ
+     </publisher>
+     <date>
+      1927
+     </date>
+    </imprint>
+   </item>
+   <item n="480" xml:id="Tolstoj_Lev_Nikolaevich_Neizdannye_teksty_1933">
+    <title type="main">
+     Толстой Л. Н. Неизданные тексты.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. Неизданные тексты. М.: Academia, 1933.
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Неизданные тексты
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Academia
+     </publisher>
+     <date>
+      1933
+     </date>
+    </imprint>
+   </item>
+   <item n="481" xml:id="Tolstoj_Lev_Nikolaevich_Neizdannye_hudozhestvennye_proizvedenija_1928">
+    <title type="main">
+     Толстой Л. Н. Неизданные художественные произведения.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. Неизданные художественные произведения. М.: «Федерация», 1928.
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Неизданные художественные произведения
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      «Федерация»
+     </publisher>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="482" xml:id="Tolstoj_Lev_Nikolaevich_Nechajanno_i_drugie_rasskazy_1912">
+    <title type="main">
+     Толстой Л. Н. Нечаянно и другие рассказы.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. Нечаянно и другие рассказы. М.: «Посредник», 1912.
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Нечаянно и другие рассказы
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      «Посредник»
+     </publisher>
+     <date>
+      1912
+     </date>
+    </imprint>
+   </item>
+   <item n="483" xml:id="Tolstoj_Lev_Nikolaevich_Polnoe_sobranie_sochinenij_1913">
+    <title type="main">
+     Толстой Л. Н. Полное собрание сочинений под ред. П. И. Бирюкова.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. Полное собрание сочинений / под ред. П. И. Бирюкова. М.: Изд. Сытина, 1913.
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <editor>
+     Бирюков П. И.
+    </editor>
+    <title level="a">
+     Полное собрание сочинений
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. Сытина
+     </publisher>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+   <item n="484" xml:id="Tolstoj_Lev_Nikolaevich_Polnoe_sobranie_sochinenij_Jubilejnoe_izdanie_1928_1958">
+    <title type="main">
+     Толстой Л. Н. Полное собрание сочинений. Юбилейное издание. Тт. 1–90.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. Полное собрание сочинений. Юбилейное издание. Тт. 1–90. М.–Л.: Гослитиздат, 1928–1958 (Юб).
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Полное собрание сочинений. Юбилейное издание
+    </title>
+    <biblScope>
+     Тт. 1–90
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Гослитиздат
+     </publisher>
+     <date>
+      1928–1958
+     </date>
+    </imprint>
+   </item>
+   <item n="485" xml:id="Tolstoj_Lev_Nikolaevich_Polnoe_sobranie_hudozhestvennyh_proizvedenij_1928">
+    <title type="main">
+     Толстой Л. Н. Полное собрание художественных произведений. М.: ГИЗ, 1928.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. Полное собрание художественных произведений. М.: ГИЗ, 1928.
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Полное собрание художественных произведений
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      ГИЗ
+     </publisher>
+     <date>
+      1928
+     </date>
+    </imprint>
+   </item>
+   <item n="486" xml:id="Tolstoj_Lev_Nikolaevich_Sbornik_statej_i_materialov_1951">
+    <title type="main">
+     Толстой Л. Н. Сборник статей и материалов.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. Сборник статей и материалов. М.: Изд. АН СССР, 1951.
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Сборник статей и материалов
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Изд. АН СССР
+     </publisher>
+     <date>
+      1951
+     </date>
+    </imprint>
+   </item>
+   <item n="487" xml:id="Tolstoj_Lev_Nikolaevich_Jubilejnyj_sbornik_1929">
+    <title type="main">
+     Толстой Л. Н. Юбилейный сборник. Собрал и редактировал Н. Н. Гусев.
+    </title>
+    <title type="bibl">
+     Толстой Л. Н. Юбилейный сборник. / Собрал и редактировал Н. Н. Гусев. М.: Госиздат, 1929.
+    </title>
+    <author>
+     Толстой Лев Николаевич
+    </author>
+    <title level="a">
+     Юбилейный сборник
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Госиздат
+     </publisher>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="488" xml:id="Rabota_nad_romanom_Dekabristy_1925">
+    <title type="main">
+     Толстой Л. Работа над романом «Декабристы».
+    </title>
+    <title type="bibl">
+     Толстой Л. Работа над романом «Декабристы». Библиотека «Огонек». М., 1925.  № 85.
+    </title>
+    <title level="a">
+     Работа над романом «Декабристы»
+    </title>
+    <biblScope>
+     № 85
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1925
+     </date>
+    </imprint>
+   </item>
+   <item n="489" xml:id="Tolstoj_Sergej_Lvovich_Ocherki_bylogo_1949">
+    <title type="main">
+     Толстой С. Л. Очерки былого.
+    </title>
+    <title type="bibl">
+     Толстой С. Л. Очерки былого. М.: Гослитиздат, 1949.
+    </title>
+    <author>
+     Толстой Сергей Львович
+    </author>
+    <title level="a">
+     Очерки былого
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Гослитиздат
+     </publisher>
+     <date>
+      1949
+     </date>
+    </imprint>
+   </item>
+   <item n="490" xml:id="Tolstoj_1850_1860_Materialy_stati_1927">
+    <title type="main">
+     Толстой. 1850–1860. Материалы, статьи.
+    </title>
+    <title type="bibl">
+     Толстой. 1850–1860. Материалы, статьи. / Ред. В. И. Срезневского. Л.: Изд. АН СССР, 1927.
+    </title>
+    <editor>
+     Срезневский В. И.
+    </editor>
+    <title level="a">
+     Толстой. 1850–1860. Материалы, статьи
+    </title>
+    <imprint>
+     <pubPlace>
+      Л.
+     </pubPlace>
+     <publisher>
+      Изд. АН СССР
+     </publisher>
+     <date>
+      1927
+     </date>
+    </imprint>
+   </item>
+   <item n="491" xml:id="Tolstoj_Pamjatniki_tvorchestva_i_zhizni_1923">
+    <title type="main">
+     Толстой. Памятники творчества и жизни. Вып. 4.
+    </title>
+    <title type="bibl">
+     Толстой. Памятники творчества и жизни. Вып. 4. М., 1923.
+    </title>
+    <title level="a">
+     Толстой. Памятники творчества и жизни
+    </title>
+    <biblScope>
+     Вып. 4
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="492" xml:id="Totleben_E_Opisanie_oborony_Sevastopolja_1872">
+    <title type="main">
+     Тотлебен Э. Описание обороны Севастополя. Ч. 2.
+    </title>
+    <title type="bibl">
+     Тотлебен Э. Описание обороны Севастополя. Ч. 2. 1872.
+    </title>
+    <author>
+     Тотлебен Э
+    </author>
+    <title level="a">
+     Описание обороны Севастополя
+    </title>
+    <biblScope>
+     Ч. 2
+    </biblScope>
+    <imprint>
+     <date>
+      1872
+     </date>
+    </imprint>
+   </item>
+   <item n="493" xml:id="Trudy_Publichnoj_biblioteki_SSSR_im_V_I_Lenina_1934">
+    <title type="main">
+     Труды Публичной библиотеки СССР им. В. И. Ленина. Вып. 3.
+    </title>
+    <title type="bibl">
+     Труды Публичной библиотеки СССР им. В. И. Ленина. Вып. 3. М.: Academia, 1934.
+    </title>
+    <title level="a">
+     Труды Публичной библиотеки СССР им. В. И. Ленина
+    </title>
+    <biblScope>
+     Вып. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Academia
+     </publisher>
+     <date>
+      1934
+     </date>
+    </imprint>
+   </item>
+   <item n="494" xml:id="Tulskie_gubernskie_vedomosti_1861">
+    <title type="main">
+     Тульские губернские ведомости. 1861. № 30 от 29 июля.
+    </title>
+    <title type="bibl">
+     Тульские губернские ведомости. 1861. № 30 от 29 июля.
+    </title>
+    <title level="a">
+     Тульские губернские ведомости
+    </title>
+    <biblScope>
+     № 30 от 29 июля
+    </biblScope>
+    <imprint>
+     <date>
+      1861
+     </date>
+    </imprint>
+   </item>
+   <item n="495" xml:id="Tulskie_gubernskie_vedomosti_1862">
+    <title type="main">
+     Тульские губернские ведомости. 1862. № 25 от 23 июня.
+    </title>
+    <title type="bibl">
+     Тульские губернские ведомости. 1862. № 25 от 23 июня.
+    </title>
+    <title level="a">
+     Тульские губернские ведомости
+    </title>
+    <biblScope>
+     № 25 от 23 июня
+    </biblScope>
+    <imprint>
+     <date>
+      1862
+     </date>
+    </imprint>
+   </item>
+   <item n="496" xml:id="Tulskie_gubernskie_vedomosti_1866">
+    <title type="main">
+     Тульские губернские ведомости. 1866. № 43 от 22 октября.
+    </title>
+    <title type="bibl">
+     Тульские губернские ведомости. 1866. № 43 от 22 октября.
+    </title>
+    <title level="a">
+     Тульские губернские ведомости
+    </title>
+    <biblScope>
+     № 43 от 22 октября
+    </biblScope>
+    <imprint>
+     <date>
+      1866
+     </date>
+    </imprint>
+   </item>
+   <item n="497" xml:id="Tulskie_gubernskie_vedomosti_1866_b">
+    <title type="main">
+     Тульские губернские ведомости. 1866. № 47 от 19 ноября.
+    </title>
+    <title type="bibl">
+     Тульские губернские ведомости. 1866. № 47 от 19 ноября.
+    </title>
+    <title level="a">
+     Тульские губернские ведомости
+    </title>
+    <biblScope>
+     № 47 от 19 ноября
+    </biblScope>
+    <imprint>
+     <date>
+      1866
+     </date>
+    </imprint>
+   </item>
+   <item n="498" xml:id="Tulskie_gubernskie_vedomosti_1869">
+    <title type="main">
+     Тульские губернские ведомости. 1869. № 42 от 18 октября.
+    </title>
+    <title type="bibl">
+     Тульские губернские ведомости. 1869. № 42 от 18 октября.
+    </title>
+    <title level="a">
+     Тульские губернские ведомости
+    </title>
+    <biblScope>
+     № 42 от 18 октября
+    </biblScope>
+    <imprint>
+     <date>
+      1869
+     </date>
+    </imprint>
+   </item>
+   <item n="499" xml:id="Tulskie_gubernskie_vedomosti_1870">
+    <title type="main">
+     Тульские губернские ведомости. 1870. № 15–16 от 11 апреля.
+    </title>
+    <title type="bibl">
+     Тульские губернские ведомости. 1870. № 15–16 от 11 апреля.
+    </title>
+    <title level="a">
+     Тульские губернские ведомости
+    </title>
+    <biblScope>
+     № 15–16 от 11 апреля
+    </biblScope>
+    <imprint>
+     <date>
+      1870
+     </date>
+    </imprint>
+   </item>
+   <item n="500" xml:id="Tulskij_oblastnoj_arhiv">
+    <title type="main">
+     Тульский областной архив.
+    </title>
+    <title type="bibl">
+     Тульский областной архив.
+    </title>
+    <title level="a">
+     Тульский областной архив
+    </title>
+   </item>
+   <item n="501" xml:id="Tulskij_spravochnyj_listok_1866">
+    <title type="main">
+     Тульский справочный листок. 1866. № 33 от 21 августа.
+    </title>
+    <title type="bibl">
+     Тульский справочный листок. 1866. № 33 от 21 августа.
+    </title>
+    <title level="a">
+     Тульский справочный листок
+    </title>
+    <biblScope>
+     № 33 от 21 августа
+    </biblScope>
+    <imprint>
+     <date>
+      1866
+     </date>
+    </imprint>
+   </item>
+   <item n="502" xml:id="Turgenev_i_krug_Sovremennika_1930">
+    <title type="main">
+     Тургенев и круг «Современника».
+    </title>
+    <title type="bibl">
+     Тургенев и круг «Современника». М.–Л.: Academia, 1930.
+    </title>
+    <title level="a">
+     Тургенев и круг «Современника»
+    </title>
+    <biblScope>
+     Вып. 2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Academia
+     </publisher>
+     <date>
+      1930
+     </date>
+    </imprint>
+   </item>
+   <item n="503" xml:id="Turgenev_Ivan_Sergeevich_Turgenev_I_S_1923">
+    <title type="main">
+     Тургенев И. С.  Документы по истории литературы и общественности. Вып. 2
+    </title>
+    <title type="bibl">
+     Тургенев И. С. М.–Пг.: Госиздат, 1923 (Центрархив. Документы по истории литературы и общественности. Вып. 2).
+    </title>
+    <author>
+     Тургенев Иван Сергеевич
+    </author>
+    <title level="a">
+     Тургенев И. С.
+    </title>
+    <biblScope>
+     Вып. 2
+    </biblScope>
+    <repository>
+     Центрархив. Документы по истории литературы и общественности. Вып. 2
+    </repository>
+    <imprint>
+     <pubPlace>
+      М.–Пг.
+     </pubPlace>
+     <publisher>
+      Госиздат
+     </publisher>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="504" xml:id="Turgenev_Ivan_Sergeevich_Pervoe_sobranie_pisem_1884">
+    <title type="main">
+     Тургенев И. С. Первое собрание писем.
+    </title>
+    <title type="bibl">
+     Тургенев И. С. Первое собрание писем. СПб., 1884.
+    </title>
+    <author>
+     Тургенев Иван Сергеевич
+    </author>
+    <title level="a">
+     Первое собрание писем
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1884
+     </date>
+    </imprint>
+   </item>
+   <item n="506" xml:id="Turgenev_Ivan_Sergeevich_Pisma_k_g_zhe_Poline_Viardo_i_ego_frantsuzskim_druzjam_1900">
+    <title type="main">
+     Тургенев И. С. Письма к г-же Полине Виардо и его французским друзьям.
+    </title>
+    <title type="bibl">
+     Тургенев И. С. Письма к г-же Полине Виардо и его французским друзьям. М., 1900.
+    </title>
+    <author>
+     Тургенев Иван Сергеевич
+    </author>
+    <title level="a">
+     Письма к г-же Полине Виардо и его французским друзьям
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1900
+     </date>
+    </imprint>
+   </item>
+   <item n="507" xml:id="Turgenev_Ivan_Sergeevich_Pismo_k_Aksakovu_S_T_1914">
+    <title type="main">
+     Тургенев И. С. Письмо к Аксакову С. Т.
+    </title>
+    <title type="bibl">
+     Тургенев И. С. Письмо к Аксакову С. Т. // Вестник Европы. 1904. № 2.
+    </title>
+    <author>
+     Тургенев Иван Сергеевич
+    </author>
+    <title level="a">
+     Письмо к Аксакову С. Т.
+    </title>
+    <title level="m">
+     Вестник Европы
+    </title>
+    <biblScope>
+     № 2
+    </biblScope>
+    <imprint>
+     <date>
+      1914
+     </date>
+    </imprint>
+   </item>
+   <item n="508" xml:id="Turgenev_Ivan_Sergeevich_Pismo_k_Annenkovu_P_V_1909">
+    <title type="main">
+     Тургенев И. С. Письмо к Анненкову П. В.
+    </title>
+    <title type="bibl">
+     Тургенев И. С. Письмо к Анненкову П. В. // Наша старина. 1914. № 11.
+    </title>
+    <author>
+     Тургенев Иван Сергеевич
+    </author>
+    <title level="a">
+     Письмо к Анненкову П. В.
+    </title>
+    <title level="m">
+     Наша старина
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="509" xml:id="Turgenev_Ivan_Sergeevich_Pismo_k_Minitskomu_I_F_1902">
+    <title type="main">
+     Тургенев И. С. Письмо к Миницкому И. Ф.
+    </title>
+    <title type="bibl">
+     Тургенев И. С. Письмо к Миницкому И. Ф. // Вестник Европы. 1909. № 8.
+    </title>
+    <author>
+     Тургенев Иван Сергеевич
+    </author>
+    <title level="a">
+     Письмо к Миницкому И. Ф.
+    </title>
+    <title level="m">
+     Вестник Европы
+    </title>
+    <biblScope>
+     № 8
+    </biblScope>
+    <imprint>
+     <date>
+      1902
+     </date>
+    </imprint>
+   </item>
+   <item n="510" xml:id="Turgenev_Ivan_Sergeevich_Pismo_k_Nekrasovu_N_A_1940">
+    <title type="main">
+     Тургенев И. С. Письмо к Некрасову Н. А.
+    </title>
+    <title type="bibl">
+     Тургенев И. С. Письмо к Некрасову Н. А. // Русская мысль. 1902. № 1.
+    </title>
+    <author>
+     Тургенев Иван Сергеевич
+    </author>
+    <title level="a">
+     Письмо к Некрасову Н. А.
+    </title>
+    <title level="m">
+     Русская мысль
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1940
+     </date>
+    </imprint>
+   </item>
+   <item n="511" xml:id="Turgenev_Ivan_Sergeevich_Sbornik_1956">
+    <title type="main">
+     Тургенев И. С. Сборник.
+    </title>
+    <title type="bibl">
+     Тургенев И. С. Сборник. / Под ред. Н. Л. Бродского. М., 1940 (Гос. Библиотека СССР им. В. И. Ленина).
+    </title>
+    <author>
+     Тургенев Иван Сергеевич
+    </author>
+    <editor>
+     Бродский Н. Л.
+    </editor>
+    <title level="a">
+     Сборник
+    </title>
+    <repository>
+     Гос. Библиотека СССР им. В. И. Ленина
+    </repository>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1956
+     </date>
+    </imprint>
+   </item>
+   <item n="512" xml:id="Turgenev_Ivan_Sergeevich_Sobranie_sochinenij_1958">
+    <title type="main">
+     Тургенев И. С. Собрание сочинений. Т. 11.
+    </title>
+    <title type="bibl">
+     Тургенев И. С. Собрание сочинений. Т. 11, М. 1956. Т. 12, М., 1958.
+    </title>
+    <author>
+     Тургенев Иван Сергеевич
+    </author>
+    <title level="a">
+     Собрание сочинений
+    </title>
+    <biblScope>
+     Т. 11; Т. 12
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1958
+     </date>
+    </imprint>
+   </item>
+   <item n="513" xml:id="Turgenev_Ivan_Sergeevich_Sochinenija_1933">
+    <title type="main">
+     Тургенев И. С. Сочинения. Т. 12.
+    </title>
+    <title type="bibl">
+     Тургенев И. С. Сочинения. Т. 12. М., 1933.
+    </title>
+    <author>
+     Тургенев Иван Сергеевич
+    </author>
+    <title level="a">
+     Сочинения
+    </title>
+    <biblScope>
+     Т. 12
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1933
+     </date>
+    </imprint>
+   </item>
+   <item n="514" xml:id="Turgenevskij_sbornik_1915">
+    <title type="main">
+     Тургеневский сборник.
+    </title>
+    <title type="bibl">
+     Тургеневский сборник. / Под ред. Н. К. Пиксанова. СПб., 1915.
+    </title>
+    <editor>
+     Пиксанов Н. К.
+    </editor>
+    <title level="a">
+     Тургеневский сборник
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1915
+     </date>
+    </imprint>
+   </item>
+   <item n="515" xml:id="Ukazatel_po_delam_pechati_1877">
+    <title type="main">
+     Указатель по делам печати. 1877. № 12–13 от 1 июля.
+    </title>
+    <title type="bibl">
+     Указатель по делам печати. 1877. № 12–13 от 1 июля.
+    </title>
+    <title level="a">
+     Указатель по делам печати
+    </title>
+    <biblScope>
+     № 12–13 от 1 июля
+    </biblScope>
+    <imprint>
+     <date>
+      1877
+     </date>
+    </imprint>
+   </item>
+   <item n="516" xml:id="Ukazatel_po_delam_pechati_1877_b">
+    <title type="main">
+     Указатель по делам печати. 1877. № 18 от 1 октября.
+    </title>
+    <title type="bibl">
+     Указатель по делам печати. 1877. № 18 от 1 октября.
+    </title>
+    <title level="a">
+     Указатель по делам печати
+    </title>
+    <biblScope>
+     № 18 от 1 октября
+    </biblScope>
+    <imprint>
+     <date>
+      1877
+     </date>
+    </imprint>
+   </item>
+   <item n="517" xml:id="Usov_P_Iz_moih_vospominanij_1884">
+    <title type="main">
+     Усов П. Из моих воспоминаний.
+    </title>
+    <title type="bibl">
+     Усов П. Из моих воспоминаний // Исторический вестник. 1884. № 3.
+    </title>
+    <author>
+     Усов П.
+    </author>
+    <title level="a">
+     Из моих воспоминаний
+    </title>
+    <title level="m">
+     Исторический вестник
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1884
+     </date>
+    </imprint>
+   </item>
+   <item n="518" xml:id="Uspenskij_D_I_Arhivnye_materialy_dlja_biografii_L_N_Tolstogo_1903">
+    <title type="main">
+     Успенский Д. И. Архивные материалы для биографии Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Успенский Д. И. Архивные материалы для биографии Л. Н. Толстого // Русская мысль. 1903. № 9.
+    </title>
+    <author>
+     Успенский Д. И.
+    </author>
+    <title level="a">
+     Архивные материалы для биографии Л. Н. Толстого
+    </title>
+    <title level="m">
+     Русская мысль
+    </title>
+    <biblScope>
+     № 9
+    </biblScope>
+    <imprint>
+     <date>
+      1903
+     </date>
+    </imprint>
+   </item>
+   <item n="519" xml:id="Uspenskij_N_V_Iz_proshlogo_1889">
+    <title type="main">
+     Успенский Н. В. Из прошлого.
+    </title>
+    <title type="bibl">
+     Успенский Н. В. Из прошлого. М., 1889.
+    </title>
+    <author>
+     Успенский Н. В.
+    </author>
+    <title level="a">
+     Из прошлого
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1889
+     </date>
+    </imprint>
+   </item>
+   <item n="520" xml:id="Pismo_iz_Moskvy_1863">
+    <title type="main">
+     Ф. В-ъ. Письмо из Москвы.
+    </title>
+    <title type="bibl">
+     Ф. В-ъ. Письмо из Москвы // Одесский вестник. 1863. № 20 от 19 февраля.
+    </title>
+    <title level="a">
+     Письмо из Москвы
+    </title>
+    <title level="m">
+     Одесский вестник
+    </title>
+    <biblScope>
+     № 20 от 19 февраля
+    </biblScope>
+    <imprint>
+     <date>
+      1863
+     </date>
+    </imprint>
+   </item>
+   <item n="521" xml:id="Fedorov_A_A_Vospominanija_1908">
+    <title type="main">
+     Федоров А. А. Воспоминания.
+    </title>
+    <title type="bibl">
+     Федоров А. А. Воспоминания // Театр. 1908. № 252.
+    </title>
+    <author>
+     Федоров А. А.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Театр
+    </title>
+    <biblScope>
+     № 252
+    </biblScope>
+    <imprint>
+     <date>
+      1908
+     </date>
+    </imprint>
+   </item>
+   <item n="522" xml:id="Feldman_O_I_Otnoshenie_Tolstogo_k_gipnotizmu_1909">
+    <title type="main">
+     Фельдман О. И. Отношение Толстого к гипнотизму.
+    </title>
+    <title type="bibl">
+     Фельдман О. И. Отношение Толстого к гипнотизму // Международный толстовский альманах, составленный П. А. Сергеенко. М., 1909.
+    </title>
+    <author>
+     Фельдман О. И.
+    </author>
+    <title level="a">
+     Отношение Толстого к гипнотизму
+    </title>
+    <title level="m">
+     Международный толстовский альманах, составленный П. А. Сергеенко
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="523" xml:id="Feoktistov_E_M_Za_kulisami_politiki_i_literatury_1848_1896_1929">
+    <title type="main">
+     Феоктистов Е. М. За кулисами политики и литературы. 1848–1896.
+    </title>
+    <title type="bibl">
+     Феоктистов Е. М. За кулисами политики и литературы. 1848–1896. Л.: «Прибой», 1929.
+    </title>
+    <author>
+     Феоктистов Е. М.
+    </author>
+    <title level="a">
+     За кулисами политики и литературы. 1848–1896
+    </title>
+    <imprint>
+     <pubPlace>
+      Л.
+     </pubPlace>
+     <publisher>
+      «Прибой»
+     </publisher>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="524" xml:id="Fet_Afanasij_Afanasevich_Moi_vospominanija_1890">
+    <title type="main">
+     Фет А. А. Мои воспоминания. Ч. 1–2.
+    </title>
+    <title type="bibl">
+     Фет А. А. Мои воспоминания. Ч. 1–2. М., 1890.
+    </title>
+    <author>
+     Фет Афанасий Афанасьевич
+    </author>
+    <title level="a">
+     Мои воспоминания
+    </title>
+    <biblScope>
+     Ч. 1–2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1890
+     </date>
+    </imprint>
+   </item>
+   <item n="525" xml:id="Fet_Afanasij_Afanasevich_Pismo_k_Strahovu_N_N_1901">
+    <title type="main">
+     Фет А. А. Письмо к Страхову Н. Н.
+    </title>
+    <title type="bibl">
+     Фет А. А. Письмо к Страхову Н. Н. // Русское обозрение. 1901. № 1.
+    </title>
+    <author>
+     Фет Афанасий Афанасьевич
+    </author>
+    <title level="a">
+     Письмо к Страхову Н. Н.
+    </title>
+    <title level="m">
+     Русское обозрение
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1901
+     </date>
+    </imprint>
+   </item>
+   <item n="526" xml:id="Formuljarnyj_spisok_L_N_Tolstogo_1948">
+    <title type="main">
+     Формулярный список Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Формулярный список Л. Н. Толстого // Летописи Гос. Литературного музея. Кн. 12. М., 1948.
+    </title>
+    <title level="a">
+     Формулярный список Л. Н. Толстого
+    </title>
+    <title level="m">
+     Летописи Гос. Литературного музея
+    </title>
+    <biblScope>
+     Кн. 12
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1948
+     </date>
+    </imprint>
+   </item>
+   <item n="527" xml:id="Formuljarnyj_spisok_N_I_Tolstogo_1939">
+    <title type="main">
+     Формулярный список Н. И. Толстого.
+    </title>
+    <title type="bibl">
+     Формулярный список Н. И. Толстого // Записки отдела рукописей Всесоюзной библиотеки СССР им. В. И. Ленина. Вып. 4. М., 1939.
+    </title>
+    <title level="a">
+     Формулярный список Н. И. Толстого
+    </title>
+    <title level="m">
+     Записки отдела рукописей Всесоюзной библиотеки СССР им. В. И. Ленина
+    </title>
+    <biblScope>
+     Вып. 4
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1939
+     </date>
+    </imprint>
+   </item>
+   <item n="528" xml:id="Hirjakov_A_M_Sestra_Tolstogo_1911">
+    <title type="main">
+     Хирьяков А. М. Сестра Толстого.
+    </title>
+    <title type="bibl">
+     Хирьяков А. М. Сестра Толстого // Русское слово. 1911. 19 августа.
+    </title>
+    <author>
+     Хирьяков А. М.
+    </author>
+    <title level="a">
+     Сестра Толстого
+    </title>
+    <title level="m">
+     Русское слово
+    </title>
+    <imprint>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="529" xml:id="Homjakov_Aleksej_Stepanovich_Sochinenija_1900">
+    <title type="main">
+     Хомяков А. С. Сочинения. Т. 3.
+    </title>
+    <title type="bibl">
+     Хомяков А. С. Сочинения. Т. 3. М., 1900.
+    </title>
+    <author>
+     Хомяков Алексей Степанович
+    </author>
+    <title level="a">
+     Сочинения
+    </title>
+    <biblScope>
+     Т. 3
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1900
+     </date>
+    </imprint>
+   </item>
+   <item n="530" xml:id="Hrabrovitskij_A_Russkie_pisateli_v_Penzenskoj_oblasti_1946">
+    <title type="main">
+     Храбровицкий А. Русские писатели в Пензенской области. / Ред. и предисловие Д. Д. Благого. Пенза: изд. газ. «Сталинское знамя», 1946.
+    </title>
+    <title type="bibl">
+     Храбровицкий А. Русские писатели в Пензенской области. / Ред. и предисловие Д. Д. Благого. Пенза: изд. газ. «Сталинское знамя», 1946.
+    </title>
+    <author>
+     Храбровицкий А.
+    </author>
+    <editor>
+     Благой Д. Д.
+    </editor>
+    <title level="a">
+     Русские писатели в Пензенской области
+    </title>
+    <imprint>
+     <pubPlace>
+      Пенза
+     </pubPlace>
+     <publisher>
+      изд. газ. «Сталинское знамя»
+     </publisher>
+     <date>
+      1946
+     </date>
+    </imprint>
+   </item>
+   <item n="531" xml:id="Tsinger_A_V_V_Jasnoj_Poljane_chetvert_veka_nazad_1914">
+    <title type="main">
+     Цингер А. В. В Ясной Поляне четверть века назад.
+    </title>
+    <title type="bibl">
+     Цингер А. В. В Ясной Поляне четверть века назад // Русское слово. 1914. № 360, 31 декабря.
+    </title>
+    <author>
+     Цингер А. В.
+    </author>
+    <title level="a">
+     В Ясной Поляне четверть века назад
+    </title>
+    <title level="m">
+     Русское слово
+    </title>
+    <biblScope>
+     № 360, 31 декабря
+    </biblScope>
+    <imprint>
+     <date>
+      1914
+     </date>
+    </imprint>
+   </item>
+   <item n="532" xml:id="Tsinger_A_V_U_Tolstogo_1909">
+    <title type="main">
+     Цингер А. В. У Толстого.
+    </title>
+    <title type="bibl">
+     Цингер А. В. У Толстого // Международный Толстовский альманах, составленный П. А. Сергеенко. М., 1909.
+    </title>
+    <author>
+     Цингер А. В.
+    </author>
+    <title level="a">
+     У Толстого
+    </title>
+    <title level="m">
+     Международный Толстовский альманах, составленный П. А. Сергеенко
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="533" xml:id="Chajkovskij_Modest_Ilich_Zhizn_Petra_Ilicha_Chajkovskogo_1903">
+    <title type="main">
+     Чайковский М. И. Жизнь Петра Ильича Чайковского. Т. 1. М., 1903.
+    </title>
+    <title type="bibl">
+     Чайковский М. И. Жизнь Петра Ильича Чайковского. Т. 1. М., 1903.
+    </title>
+    <author>
+     Чайковский Модест Ильич
+    </author>
+    <title level="a">
+     Жизнь Петра Ильича Чайковского
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1903
+     </date>
+    </imprint>
+   </item>
+   <item n="534" xml:id="Chajkovskij_Petr_Ilich_Dnevnik_1923">
+    <title type="main">
+     Чайковский П. И. Дневник.
+    </title>
+    <title type="bibl">
+     Чайковский П. И. Дневник. Госиздат, 1923.
+    </title>
+    <author>
+     Чайковский Петр Ильич
+    </author>
+    <title level="a">
+     Дневник
+    </title>
+    <imprint>
+     <publisher>
+      Госиздат
+     </publisher>
+     <date>
+      1923
+     </date>
+    </imprint>
+   </item>
+   <item n="535" xml:id="Chajkovskij_Petr_Ilich_Mekk_N_F_Perepiska_1934">
+    <title type="main">
+     Чайковский П. И. и Мекк Н. Ф. Переписка. Т. 1. 1876–1878.
+    </title>
+    <title type="bibl">
+     Чайковский П. И. и Мекк Н. Ф. Переписка. Т. 1. 1876–1878. М., 1934.
+    </title>
+    <author>
+     Чайковский Петр Ильич, Мекк Н. Ф.
+    </author>
+    <title level="a">
+     Переписка
+    </title>
+    <biblScope>
+     Т. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1934
+     </date>
+    </imprint>
+   </item>
+   <item n="536" xml:id="Chernopjatov_N_I_Dvorjanskoe_soslovie_Tulskoj_gub_1909">
+    <title type="main">
+     Чернопятов Н. И. Дворянское сословие Тульской губ. Т. 3. Ч. 5.
+    </title>
+    <title type="bibl">
+     Чернопятов Н. И. Дворянское сословие Тульской губ. Т. 3. Ч. 5. Родословец. 1909.
+    </title>
+    <author>
+     Чернопятов Н. И.
+    </author>
+    <title level="a">
+     Дворянское сословие Тульской губ.
+    </title>
+    <biblScope>
+     Т. 3, Ч. 5
+    </biblScope>
+    <imprint>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="537" xml:id="Chernyshevskij_Nikolaj_Gavrilovich_Voennye_rasskazy_gr_L_N_Tolstogo_1856">
+    <title type="main">
+     Чернышевский Н. Г. Военные рассказы гр. Л. Н. Толстого
+    </title>
+    <title type="bibl">
+     Чернышевский Н. Г. Военные рассказы гр. Л. Н. Толстого // Современник. 1856. № 12.
+    </title>
+    <author>
+     Чернышевский Николай Гаврилович
+    </author>
+    <title level="a">
+     Военные рассказы гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Современник
+    </title>
+    <biblScope>
+     № 12
+    </biblScope>
+    <imprint>
+     <date>
+      1856
+     </date>
+    </imprint>
+   </item>
+   <item n="538" xml:id="Chernyshevskij_Nikolaj_Gavrilovich_Detstvo_i_otrochestvo_Sochinenie_gr_L_N_Tolstogo_1856">
+    <title type="main">
+     Чернышевский Н. Г. Детство и отрочество. Сочинение гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Чернышевский Н. Г. Детство и отрочество. Сочинение гр. Л. Н. Толстого // Современник. 1856. № 12.
+    </title>
+    <author>
+     Чернышевский Николай Гаврилович
+    </author>
+    <title level="a">
+     Детство и отрочество. Сочинение гр. Л. Н. Толстого
+    </title>
+    <title level="m">
+     Современник
+    </title>
+    <biblScope>
+     № 12
+    </biblScope>
+    <imprint>
+     <date>
+      1856
+     </date>
+    </imprint>
+   </item>
+   <item n="539" xml:id="Chernyshevskij_Nikolaj_Gavrilovich_Zametki_o_zhurnalah_dekabr_1856_1857">
+    <title type="main">
+     Чернышевский Н. Г. Заметки о журналах, декабрь 1856.
+    </title>
+    <title type="bibl">
+     Чернышевский Н. Г. Заметки о журналах, декабрь 1856 // Современник. 1857. № 1.
+    </title>
+    <author>
+     Чернышевский Николай Гаврилович
+    </author>
+    <title level="a">
+     Заметки о журналах, декабрь 1856
+    </title>
+    <title level="m">
+     Современник
+    </title>
+    <biblScope>
+     № 1
+    </biblScope>
+    <imprint>
+     <date>
+      1857
+     </date>
+    </imprint>
+   </item>
+   <item n="540" xml:id="Chernyshevskij_Nikolaj_Gavrilovich_Polnoe_sobranie_sochinenij_1949">
+    <title type="main">
+     Чернышевский Н. Г. Полное собрание сочинений. Т. 14.
+    </title>
+    <title type="bibl">
+     Чернышевский Н. Г. Полное собрание сочинений. Т. 14. М.: Гослитиздат, 1949.
+    </title>
+    <author>
+     Чернышевский Николай Гаврилович
+    </author>
+    <title level="a">
+     Полное собрание сочинений
+    </title>
+    <biblScope>
+     Т. 14
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Гослитиздат
+     </publisher>
+     <date>
+      1949
+     </date>
+    </imprint>
+   </item>
+   <item n="541" xml:id="Chernyshevskij_Nikolaj_Gavrilovich_Jasnaja_Poljana_Shkola_1862">
+    <title type="main">
+     Чернышевский Н. Г. Ясная Поляна. Школа.
+    </title>
+    <title type="bibl">
+     Чернышевский Н. Г. Ясная Поляна. Школа // Современник. 1862. № 3.
+    </title>
+    <author>
+     Чернышевский Николай Гаврилович
+    </author>
+    <title level="a">
+     Ясная Поляна. Школа
+    </title>
+    <title level="m">
+     Современник
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1862
+     </date>
+    </imprint>
+   </item>
+   <item n="542" xml:id="Chertkov_Vladimir_Grigorevich_Dnevnik_1939">
+    <title type="main">
+     Чертков В. Г. Дневник.
+    </title>
+    <title type="bibl">
+     Чертков В. Г. Дневник // Литературное наследство. № 37–38. М., 1939.
+    </title>
+    <author>
+     Чертков Владимир Григорьевич
+    </author>
+    <title level="a">
+     Дневник
+    </title>
+    <title level="m">
+     Литературное наследство
+    </title>
+    <biblScope>
+     № 37–38
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1939
+     </date>
+    </imprint>
+   </item>
+   <item n="543" xml:id="Chertkova_A_K_Vospominanija_1929">
+    <title type="main">
+     Черткова А. К. Воспоминания.
+    </title>
+    <title type="bibl">
+     Черткова А. К. Воспоминания // Толстой Л. Н. Юбилейный сборник. М.–Л., 1929.
+    </title>
+    <author>
+     Черткова А. К.
+    </author>
+    <title level="a">
+     Воспоминания
+    </title>
+    <title level="m">
+     Толстой Л. Н. Юбилейный сборник
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="544" xml:id="Chehov_Anton_Pavlovich_Polnoe_sobranie_sochinenij_i_pisem_1949">
+    <title type="main">
+     Чехов А. П. Полное собрание сочинений и писем. Т. XIV.
+    </title>
+    <title type="bibl">
+     Чехов А. П. Полное собрание сочинений и писем. Т. XIV. М.: Гослитиздат, 1949.
+    </title>
+    <author>
+     Чехов Антон Павлович
+    </author>
+    <title level="a">
+     Полное собрание сочинений и писем
+    </title>
+    <biblScope>
+     Т. XIV
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Гослитиздат
+     </publisher>
+     <date>
+      1949
+     </date>
+    </imprint>
+   </item>
+   <item n="545" xml:id="Chicherin_B_N_Vospominanija_Moskva_sorokovyh_godov_1929">
+    <title type="main">
+     Чичерин Б. Н. Воспоминания. Москва сороковых годов.
+    </title>
+    <title type="bibl">
+     Чичерин Б. Н. Воспоминания. Москва сороковых годов. М.: Изд. М. и С. Сабашниковых, 1929.
+    </title>
+    <author>
+     Чичерин Б. Н.
+    </author>
+    <title level="a">
+     Воспоминания. Москва сороковых годов
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1929
+     </date>
+    </imprint>
+   </item>
+   <item n="546" xml:id="Chtenija_v_obschestve_ljubitelej_istorii_i_drevnostej_rossijskih_1874">
+    <title type="main">
+     Чтения в обществе любителей истории и древностей российских. Кн. 1. 1874.
+    </title>
+    <title type="bibl">
+     Чтения в обществе любителей истории и древностей российских. Кн. 1. 1874.
+    </title>
+    <title level="a">
+     Чтения в обществе любителей истории и древностей российских
+    </title>
+    <biblScope>
+     Кн. 1
+    </biblScope>
+    <imprint>
+     <date>
+      1874
+     </date>
+    </imprint>
+   </item>
+   <item n="547" xml:id="Chukovskij_Kornej_Ljudi_i_knigi_shestidesjatyh_godov_1934">
+    <title type="main">
+     Чуковский К. Люди и книги шестидесятых годов.
+    </title>
+    <title type="bibl">
+     Чуковский К. Люди и книги шестидесятых годов. Л.: Изд-во писателей, 1934.
+    </title>
+    <author>
+     Чуковский Корней
+    </author>
+    <title level="a">
+     Люди и книги шестидесятых годов
+    </title>
+    <imprint>
+     <pubPlace>
+      Л.
+     </pubPlace>
+     <publisher>
+      Изд-во писателей
+     </publisher>
+     <date>
+      1934
+     </date>
+    </imprint>
+   </item>
+   <item n="548" xml:id="Chulkov_G_Letopis_zhizni_i_tvorchestva_F_I_Tjutcheva_1933">
+    <title type="main">
+     Чулков Г. Летопись жизни и творчества Ф. И. Тютчева.
+    </title>
+    <title type="bibl">
+     Чулков Г. Летопись жизни и творчества Ф. И. Тютчева. М.: Academia, 1933.
+    </title>
+    <author>
+     Чулков Г.
+    </author>
+    <title level="a">
+     Летопись жизни и творчества Ф. И. Тютчева
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <publisher>
+      Academia
+     </publisher>
+     <date>
+      1933
+     </date>
+    </imprint>
+   </item>
+   <item n="549" xml:id="Shatilov_I_N_Iz_nedavnego_proshlogo_1916">
+    <title type="main">
+     Шатилов И. Н. Из недавнего прошлого.
+    </title>
+    <title type="bibl">
+     Шатилов И. Н. Из недавнего прошлого // Голос минувшего. 1916. № 10.
+    </title>
+    <author>
+     Шатилов И. Н.
+    </author>
+    <title level="a">
+     Из недавнего прошлого
+    </title>
+    <title level="m">
+     Голос минувшего
+    </title>
+    <biblScope>
+     № 10
+    </biblScope>
+    <imprint>
+     <date>
+      1916
+     </date>
+    </imprint>
+   </item>
+   <item n="550" xml:id="Shevchenko_Taras_Grigorevich_Dnevnik_1954">
+    <title type="main">
+     Шевченко Т. Г. Дневник.
+    </title>
+    <title type="bibl">
+     Шевченко Т. Г. Дневник. М., 1954.
+    </title>
+    <author>
+     Шевченко Тарас Григорьевич
+    </author>
+    <title level="a">
+     Дневник
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1954
+     </date>
+    </imprint>
+   </item>
+   <item n="551" xml:id="Sheremete_P_S_I_F_Gorbunov_1898">
+    <title type="main">
+     Шереметев П. С. И. Ф. Горбунов.
+    </title>
+    <title type="bibl">
+     Шереметев П. С. И. Ф. Горбунов // Русская старина. 1898. № 3.
+    </title>
+    <author>
+     Шеремете П. С.
+    </author>
+    <title level="a">
+     И. Ф. Горбунов
+    </title>
+    <title level="m">
+     Русская старина
+    </title>
+    <biblScope>
+     № 3
+    </biblScope>
+    <imprint>
+     <date>
+      1898
+     </date>
+    </imprint>
+   </item>
+   <item n="552" xml:id="Shestidesjatye_gody_Materialy_po_istorii_literatury_i_obschestvennogo_dvizhenija_1940">
+    <title type="main">
+     Шестидесятые годы. Материалы по истории литературы и общественного движения.
+    </title>
+    <title type="bibl">
+     Шестидесятые годы. Материалы по истории литературы и общественного движения. / Ред. А. Цехновицера и Н. Пиксанова. М., 1940.
+    </title>
+    <editor>
+     Цехновицер А. и Пиксанов Н.
+    </editor>
+    <title level="a">
+     Шестидесятые годы. Материалы по истории литературы и общественного движения
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1940
+     </date>
+    </imprint>
+   </item>
+   <item n="553" xml:id="Shljapkin_I_A_Pamjati_gr_L_N_Tolstogo_1911">
+    <title type="main">
+     Шляпкин И. А. Памяти гр. Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Шляпкин И. А. Памяти гр. Л. Н. Толстого. СПб., 1911.
+    </title>
+    <author>
+     Шляпкин И. А.
+    </author>
+    <title level="a">
+     Памяти гр. Л. Н. Толстого
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1911
+     </date>
+    </imprint>
+   </item>
+   <item n="554" xml:id="Shtakenshnejder_E_A_Dnevnik_i_zapiski_1934">
+    <title type="main">
+     Штакеншнейдер Е. А. Дневник и записки.
+    </title>
+    <title type="bibl">
+     Штакеншнейдер Е. А. Дневник и записки. М.–Л.: Academia, 1934.
+    </title>
+    <author>
+     Штакеншнейдер Е. А.
+    </author>
+    <title level="a">
+     Дневник и записки
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      Academia
+     </publisher>
+     <date>
+      1934
+     </date>
+    </imprint>
+   </item>
+   <item n="555" xml:id="Schukinskij_sbornik_1909">
+    <title type="main">
+     Щукинский сборник. Вып. 8.
+    </title>
+    <title type="bibl">
+     Щукинский сборник. Вып. 8. М., 1909.
+    </title>
+    <title level="a">
+     Щукинский сборник
+    </title>
+    <biblScope>
+     Вып. 8
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="556" xml:id="Ejhenbaum_Boris_Mihajlovich_Lev_Tolstoj_1931">
+    <title type="main">
+     Эйхенбаум Б. М. Лев Толстой. II.
+    </title>
+    <title type="bibl">
+     Эйхенбаум Б. М. Лев Толстой. II. М.–Л.: ГИХЛ, 1931.
+    </title>
+    <author>
+     Эйхенбаум Борис Михайлович
+    </author>
+    <title level="a">
+     Лев Толстой
+    </title>
+    <imprint>
+     <pubPlace>
+      М.–Л.
+     </pubPlace>
+     <publisher>
+      ГИХЛ
+     </publisher>
+     <date>
+      1931
+     </date>
+    </imprint>
+   </item>
+   <item n="557" xml:id="Ertel_A_I_Pisma_1909">
+    <title type="main">
+     Эртель А. И. Письма.
+    </title>
+    <title type="bibl">
+     Эртель А. И. Письма. / Ред. и примеч. М. Гершензона. М., 1909.
+    </title>
+    <author>
+     Эртель А. И.
+    </author>
+    <editor>
+     Гершензон М.
+    </editor>
+    <title level="a">
+     Письма
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="558" xml:id="Jablochkov_M_T_Dvorjanskoe_soslovie_Tulskoj_gub_1904">
+    <title type="main">
+     Яблочков М. Т. Дворянское сословие Тульской губ. Т. 5. Ч. 1.
+    </title>
+    <title type="bibl">
+     Яблочков М. Т. Дворянское сословие Тульской губ. Т. 5. Ч. 1. Тула, 1904.
+    </title>
+    <author>
+     Яблочков М. Т.
+    </author>
+    <title level="a">
+     Дворянское сословие Тульской губ.
+    </title>
+    <biblScope>
+     Т. 5, Ч. 1
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Тула
+     </pubPlace>
+     <date>
+      1904
+     </date>
+    </imprint>
+   </item>
+   <item n="559" xml:id="Jakubovskij_Ju_L_N_Tolstoj_i_ego_druzja_1914">
+    <title type="main">
+     Якубовский Ю. О. Л. Н. Толстой и его друзья.
+    </title>
+    <title type="bibl">
+     Якубовский Ю. О. Л. Н. Толстой и его друзья // Толстовский ежегодник 1913 г. СПб., 1914.
+    </title>
+    <author>
+     Якубовский Ю.
+    </author>
+    <title level="a">
+     Л. Н. Толстой и его друзья
+    </title>
+    <title level="m">
+     Толстовский ежегодник 1913 г.
+    </title>
+    <imprint>
+     <pubPlace>
+      СПб.
+     </pubPlace>
+     <date>
+      1914
+     </date>
+    </imprint>
+   </item>
+   <item n="560" xml:id="Jakushkin_Vjacheslav_Evgenevich_M_N_Muravev_Apostol_1886">
+    <title type="main">
+     Якушкин В. Е. М. Н. Муравьев-Апостол.
+    </title>
+    <title type="bibl">
+     Якушкин В. Е. М. Н. Муравьев-Апостол // Русская старина. 1886. № 7.
+    </title>
+    <author>
+     Якушкин Вячеслав Евгеньевич
+    </author>
+    <title level="a">
+     М. Н. Муравьев-Апостол
+    </title>
+    <title level="m">
+     Русская старина
+    </title>
+    <biblScope>
+     № 7
+    </biblScope>
+    <imprint>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="561" xml:id="Janzhul_E_N_Vstrechi_s_Tolstym_1909">
+    <title type="main">
+     Янжул Е. Н. Встречи с Толстым.
+    </title>
+    <title type="bibl">
+     Янжул Е. Н. Встречи с Толстым // Международный Толстовский альманах, составленный П. А. Сергеенко. М., 1909.
+    </title>
+    <author>
+     Янжул Е. Н.
+    </author>
+    <title level="a">
+     Встречи с Толстым
+    </title>
+    <title level="m">
+     Международный Толстовский альманах, составленный П. А. Сергеенко
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="562" xml:id="Janzhul_I_I_Moe_znakomstvo_s_Tolstym_1909">
+    <title type="main">
+     Янжул И. И. Мое знакомство с Толстым.
+    </title>
+    <title type="bibl">
+     Янжул И. И. Мое знакомство с Толстым // Международный Толстовский альманах, составленный П. А. Сергеенко. М., 1909.
+    </title>
+    <author>
+     Янжул И. И.
+    </author>
+    <title level="a">
+     Мое знакомство с Толстым
+    </title>
+    <title level="m">
+     Международный Толстовский альманах, составленный П. А. Сергеенко
+    </title>
+    <imprint>
+     <pubPlace>
+      М.
+     </pubPlace>
+     <date>
+      1909
+     </date>
+    </imprint>
+   </item>
+   <item n="563" xml:id="Janzhul_M_A_K_biografii_L_N_Tolstogo_1900">
+    <title type="main">
+     Янжул М. А. К биографии Л. Н. Толстого.
+    </title>
+    <title type="bibl">
+     Янжул М. А. К биографии Л. Н. Толстого // Русская старина. 1900. № 2.
+    </title>
+    <author>
+     Янжул М. А
+    </author>
+    <title level="a">
+     К биографии Л. Н. Толстого
+    </title>
+    <title level="m">
+     Русская старина
+    </title>
+    <biblScope>
+     № 2
+    </biblScope>
+    <imprint>
+     <date>
+      1900
+     </date>
+    </imprint>
+   </item>
+   <item n="564" xml:id="Janzhul_M_Vosemdesjat_let_boevoj_i_mirnoj_zhizni_20_j_artillerijskoj_brigady_1886">
+    <title type="main">
+     Янжул М. Восемьдесят лет боевой и мирной жизни 20-й артиллерийской бригады.
+    </title>
+    <title type="bibl">
+     Янжул М. Восемьдесят лет боевой и мирной жизни 20-й артиллерийской бригады. Тифлис, 1886.
+    </title>
+    <author>
+     Янжул М.
+    </author>
+    <title level="a">
+     Восемьдесят лет боевой и мирной жизни 20-й артиллерийской бригады
+    </title>
+    <imprint>
+     <pubPlace>
+      Тифлис
+     </pubPlace>
+     <date>
+      1886
+     </date>
+    </imprint>
+   </item>
+   <item n="565" xml:id="Jasnopoljanskij_sbornik_1955">
+    <title type="main">
+     Яснополянский сборник. Год 1955.
+    </title>
+    <title type="bibl">
+     Яснополянский сборник. Год 1955. Тула, 1955.
+    </title>
+    <title level="a">
+     Яснополянский сборник
+    </title>
+    <imprint>
+     <pubPlace>
+      Тула
+     </pubPlace>
+     <date>
+      1955
+     </date>
+    </imprint>
+   </item>
+   <item n="566" xml:id="Jatsimirskij_A_I_Vospominanija_pisatelej_samorodkov_1902">
+    <title type="main">
+     Яцимирский А. И. Воспоминания писателей-самородков.
+    </title>
+    <title type="bibl">
+     Яцимирский А. И. Воспоминания писателей-самородков // Русская мысль. 1902. № 11.
+    </title>
+    <author>
+     Яцимирский А. И.
+    </author>
+    <title level="a">
+     Воспоминания писателей-самородков
+    </title>
+    <title level="m">
+     Русская мысль
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1902
+     </date>
+    </imprint>
+   </item>
+   <item n="567" xml:id="Bode_W_Tolstoi_in_Weimar_1905">
+    <title type="main">
+     Bode W. Tolstoi in Weimar.
+    </title>
+    <title type="bibl">
+     Bode W. Tolstoi in Weimar // Der Saeman. 1905.
+    </title>
+    <author>
+     Bode W.
+    </author>
+    <title level="a">
+     Tolstoi in Weimar
+    </title>
+    <title level="m">
+     Der Saeman
+    </title>
+    <imprint>
+     <date>
+      1905
+     </date>
+    </imprint>
+   </item>
+   <item n="568" xml:id="Fr_bel_J_Ein_Lebenslauf_1891">
+    <title type="main">
+     Fröbel  J. Ein Lebenslauf. B. 2.
+    </title>
+    <title type="bibl">
+     Fröbel  J. Ein Lebenslauf. B. 2. Stuttgart, 1891.
+    </title>
+    <author>
+     Fröbel  J.
+    </author>
+    <title level="a">
+     Ein Lebenslauf
+    </title>
+    <biblScope>
+     B. 2
+    </biblScope>
+    <imprint>
+     <pubPlace>
+      Stuttgart
+     </pubPlace>
+     <date>
+      1891
+     </date>
+    </imprint>
+   </item>
+   <item n="569" xml:id="Kennann_G_A_visit_to_count_Tolstoi_1887">
+    <title type="main">
+     Kennann G. A visit to count Tolstoi.
+    </title>
+    <title type="bibl">
+     Kennann G. A visit to count Tolstoi // The Century. 1887. № 34; Неделя 1887. № 28.
+    </title>
+    <author>
+     Kennann G.
+    </author>
+    <title level="a">
+     A visit to count Tolstoi
+    </title>
+    <title level="m">
+     The Century
+    </title>
+    <biblScope>
+     № 34; № 28
+    </biblScope>
+    <imprint>
+     <date>
+      1887
+     </date>
+    </imprint>
+   </item>
+   <item n="570" xml:id="Kennann_G_Political_exiles_and_common_convicts_at_Tomsk_1888">
+    <title type="main">
+     Kennann G. Political exilles and common convids at Tomsk.
+    </title>
+    <title type="bibl">
+     Kennann G. Political exilles and common convids at Tomsk  // The century illustrated Monthly Magazine. 1888. № 5.
+    </title>
+    <author>
+     Kennann G.
+    </author>
+    <title level="a">
+     Political exiles and common convicts at Tomsk
+    </title>
+    <title level="m">
+     The century illustrated Monthly Magazine
+    </title>
+    <biblScope>
+     № 5
+    </biblScope>
+    <imprint>
+     <date>
+      1888
+     </date>
+    </imprint>
+   </item>
+   <item n="571" xml:id="Aus_dem_Leben_Leo_Tolstoi_s_1888">
+    <title type="main">
+     L. T. Aus dem Leben Leo Tolstoi’s.
+    </title>
+    <title type="bibl">
+     L. T. Aus dem Leben Leo Tolstoi’s // Duna-zeitung. 1888. № 76.
+    </title>
+    <title level="a">
+     Aus dem Leben Leo Tolstoi’s
+    </title>
+    <title level="m">
+     Duna-zeitung
+    </title>
+    <biblScope>
+     № 76
+    </biblScope>
+    <imprint>
+     <date>
+      1888
+     </date>
+    </imprint>
+   </item>
+   <item n="572" xml:id="Correspondence">
+    <title type="main">
+     Proudonn. Correspondence. T. 10.
+    </title>
+    <title type="bibl">
+     Proudonn. Correspondence. T. 10.
+    </title>
+    <title level="a">
+     Correspondence
+    </title>
+    <biblScope>
+     Т. 10
+    </biblScope>
+   </item>
+   <item n="573" xml:id="Erinnerungen_von_einem_Balte_1898">
+    <title type="main">
+     Tolstoi. Erinnerungen von einem Balte.
+    </title>
+    <title type="bibl">
+     Tolstoi. Erinnerungen von einem Balte // Duna-zeitung. 1898. № 181.
+    </title>
+    <title level="a">
+     Erinnerungen von einem Balte
+    </title>
+    <title level="m">
+     Duna-zeitung
+    </title>
+    <biblScope>
+     № 181
+    </biblScope>
+    <imprint>
+     <date>
+      1898
+     </date>
+    </imprint>
+   </item>
+   <item n="574" xml:id="Proshlaja_nedelja_1868">
+    <title type="main">
+     X. Л. Прошлая неделя.
+    </title>
+    <title type="bibl">
+     X. Л. Прошлая неделя // Голос. 1868. № 63.
+    </title>
+    <title level="a">
+     Прошлая неделя
+    </title>
+    <title level="m">
+     Голос
+    </title>
+    <biblScope>
+     № 63
+    </biblScope>
+    <imprint>
+     <date>
+      1868
+     </date>
+    </imprint>
+   </item>
+   <item n="575" xml:id="Ashevskij_S_Jasnaja_Poljana_L_Tolstogo_v_kritike_60_h_godov_1913_b">
+    <title type="main">
+     Ашевский С. «Ясная Поляна» Л. Толстого в критике 60-х годов
+    </title>
+    <title type="bibl">
+     Ашевский С. «Ясная Поляна» Л. Толстого в критике 60-х годов // Русская школа. 1913. № 11.
+    </title>
+    <author>
+     Ашевский С.
+    </author>
+    <title level="a">
+     «Ясная Поляна» Л. Толстого в критике 60-х годов
+    </title>
+    <title level="m">
+     Русская школа
+    </title>
+    <biblScope>
+     № 11
+    </biblScope>
+    <imprint>
+     <date>
+      1913
+     </date>
+    </imprint>
+   </item>
+  </list>
+ </standOff>
+</TEI>

--- a/reference/sourceList.xml
+++ b/reference/sourceList.xml
@@ -68,7 +68,7 @@
      </date>
     </imprint>
    </item>
-   <item n="2" xml:id="Tolstoj_Lev_Nikolaevich_Azbuka_1873_b">
+   <item n="2" xml:id="Tolstoj_Lev_Nikolaevich_Azbuka_1873_a">
     <title type="main">
      «Азбука» гр. Л. Н. Толстого.
     </title>
@@ -1906,7 +1906,7 @@
      </date>
     </imprint>
    </item>
-   <item n="83" xml:id="Gertsen_Aleksandr_Ivanovich_Polnoe_sobranie_sochinenij_1919_b">
+   <item n="83" xml:id="Gertsen_Aleksandr_Ivanovich_Polnoe_sobranie_sochinenij_1919_a">
     <title type="main">
      Герцен А. И. Полное собрание сочинений. / Ред. М. К. Лемке. Т. 9.
     </title>
@@ -2260,7 +2260,7 @@
      </date>
     </imprint>
    </item>
-   <item n="98" xml:id="Gribovskij_V_U_gr_L_N_Tolstogo_1886_b">
+   <item n="98" xml:id="Gribovskij_V_U_gr_L_N_Tolstogo_1886_a">
     <title type="main">
      Грибовский В. У гр. Л. Н. Толстого.
     </title>
@@ -4378,7 +4378,7 @@
      </date>
     </imprint>
    </item>
-   <item n="192" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_b">
+   <item n="192" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_a">
     <title type="main">
      Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
     </title>
@@ -4403,7 +4403,7 @@
      </date>
     </imprint>
    </item>
-   <item n="193" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_c">
+   <item n="193" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_b">
     <title type="main">
      Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
     </title>
@@ -4428,7 +4428,7 @@
      </date>
     </imprint>
    </item>
-   <item n="194" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_d">
+   <item n="194" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_c">
     <title type="main">
      Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
     </title>
@@ -4453,7 +4453,7 @@
      </date>
     </imprint>
    </item>
-   <item n="195" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_e">
+   <item n="195" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_d">
     <title type="main">
      Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
     </title>
@@ -4478,7 +4478,7 @@
      </date>
     </imprint>
    </item>
-   <item n="196" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_f">
+   <item n="196" xml:id="Leskov_Nikolaj_Semenovich_Geroi_Otechestvennoj_vojny_po_gr_L_N_Tolstomu_1869_e">
     <title type="main">
      Лесков Н. С. Герои Отечественной войны по гр. Л. Н. Толстому.
     </title>
@@ -5284,7 +5284,7 @@
      </date>
     </imprint>
    </item>
-   <item n="232" xml:id="Moskovskie_vedomosti_1868_b">
+   <item n="232" xml:id="Moskovskie_vedomosti_1868_a">
     <title type="main">
      Московские ведомости. 1868. № 19 от 25 января.
     </title>
@@ -5778,7 +5778,7 @@
      Российская государственная библиотека
     </repository>
    </item>
-   <item n="261" xml:id="Neopublikovannye_pisma_I_P_Borisova_b">
+   <item n="261" xml:id="Neopublikovannye_pisma_I_P_Borisova_a">
     <title type="main">
      Неопубликованные письма И. П. Борисова.
     </title>
@@ -6404,7 +6404,7 @@
      </date>
     </imprint>
    </item>
-   <item n="300" xml:id="Objavlenija_1856_b">
+   <item n="300" xml:id="Objavlenija_1856_a">
     <title type="main">
      Объявления. — «Русский инвалид» 1856, № 9 от 12 января.
     </title>
@@ -6448,7 +6448,7 @@
      </date>
     </imprint>
    </item>
-   <item n="302" xml:id="Objavlenija_1856_c">
+   <item n="302" xml:id="Objavlenija_1856_b">
     <title type="main">
      Объявления. — «Санкт-Петербургские ведомости» 1856, № 106 от 13 мая.
     </title>
@@ -6495,7 +6495,7 @@
      </date>
     </imprint>
    </item>
-   <item n="304" xml:id="Objavlenija_1855_b">
+   <item n="304" xml:id="Objavlenija_1855_a">
     <title type="main">
      Объявления. — «Сев. Пчела» 1855, № 195 от 7 сентября.
     </title>
@@ -7527,7 +7527,7 @@
      </date>
     </imprint>
    </item>
-   <item n="350" xml:id="Pravitelstvennyj_vestnik_1880_b">
+   <item n="350" xml:id="Pravitelstvennyj_vestnik_1880_a">
     <title type="main">
      Правительственный вестник. 1880. № 145 от 29 июня.
     </title>
@@ -7546,7 +7546,7 @@
      </date>
     </imprint>
    </item>
-   <item n="351" xml:id="Pravitelstvennyj_vestnik_1880_c">
+   <item n="351" xml:id="Pravitelstvennyj_vestnik_1880_b">
     <title type="main">
      Правительственный вестник. 1880. № 152 от 8 июля.
     </title>
@@ -7565,7 +7565,7 @@
      </date>
     </imprint>
    </item>
-   <item n="352" xml:id="Pravitelstvennyj_vestnik_1880_d">
+   <item n="352" xml:id="Pravitelstvennyj_vestnik_1880_c">
     <title type="main">
      Правительственный вестник. 1880. № 186 от 20 августа.
     </title>
@@ -7603,7 +7603,7 @@
      </date>
     </imprint>
    </item>
-   <item n="354" xml:id="Pravitelstvennyj_vestnik_1885_b">
+   <item n="354" xml:id="Pravitelstvennyj_vestnik_1885_a">
     <title type="main">
      Правительственный вестник. 1885. № 280.
     </title>
@@ -7622,7 +7622,7 @@
      </date>
     </imprint>
    </item>
-   <item n="355" xml:id="Pravitelstvennyj_vestnik_1885_c">
+   <item n="355" xml:id="Pravitelstvennyj_vestnik_1885_b">
     <title type="main">
      Правительственный вестник. 1885. № 282 от 25 декабря.
     </title>
@@ -7660,7 +7660,7 @@
      </date>
     </imprint>
    </item>
-   <item n="357" xml:id="Pravitelstvennyj_vestnik_1886_b">
+   <item n="357" xml:id="Pravitelstvennyj_vestnik_1886_a">
     <title type="main">
      Правительственный вестник. 1886. № 274 от 14 декабря.
     </title>
@@ -7679,7 +7679,7 @@
      </date>
     </imprint>
    </item>
-   <item n="358" xml:id="Pravitelstvennyj_vestnik_1886_c">
+   <item n="358" xml:id="Pravitelstvennyj_vestnik_1886_b">
     <title type="main">
      Правительственный вестник. 1886. № 50.
     </title>
@@ -7717,7 +7717,7 @@
      </date>
     </imprint>
    </item>
-   <item n="360" xml:id="Pravitelstvennyj_vestnik_1887_b">
+   <item n="360" xml:id="Pravitelstvennyj_vestnik_1887_a">
     <title type="main">
      Правительственный вестник. 1887. № 142 от 2 июля.
     </title>
@@ -7736,7 +7736,7 @@
      </date>
     </imprint>
    </item>
-   <item n="361" xml:id="Pravitelstvennyj_vestnik_1887_c">
+   <item n="361" xml:id="Pravitelstvennyj_vestnik_1887_b">
     <title type="main">
      Правительственный вестник. 1887. № 154 от 19 июля.
     </title>
@@ -7755,7 +7755,7 @@
      </date>
     </imprint>
    </item>
-   <item n="362" xml:id="Pravitelstvennyj_vestnik_1887_d">
+   <item n="362" xml:id="Pravitelstvennyj_vestnik_1887_c">
     <title type="main">
      Правительственный вестник. 1887. № 31 от 3 февраля.
     </title>
@@ -7774,7 +7774,7 @@
      </date>
     </imprint>
    </item>
-   <item n="363" xml:id="Pravitelstvennyj_vestnik_1887_e">
+   <item n="363" xml:id="Pravitelstvennyj_vestnik_1887_d">
     <title type="main">
      Правительственный вестник. 1887. № 46 от 1 марта.
     </title>
@@ -7812,7 +7812,7 @@
      </date>
     </imprint>
    </item>
-   <item n="365" xml:id="Pravitelstvennyj_vestnik_1889_b">
+   <item n="365" xml:id="Pravitelstvennyj_vestnik_1889_a">
     <title type="main">
      Правительственный вестник. 1889. № 142 от 2 июля.
     </title>
@@ -7831,7 +7831,7 @@
      </date>
     </imprint>
    </item>
-   <item n="366" xml:id="Pravitelstvennyj_vestnik_1889_c">
+   <item n="366" xml:id="Pravitelstvennyj_vestnik_1889_b">
     <title type="main">
      Правительственный вестник. 1889. № 159 от 22 июля.
     </title>
@@ -7850,7 +7850,7 @@
      </date>
     </imprint>
    </item>
-   <item n="367" xml:id="Pravitelstvennyj_vestnik_1889_d">
+   <item n="367" xml:id="Pravitelstvennyj_vestnik_1889_c">
     <title type="main">
      Правительственный вестник. 1889. № 188 от 27 августа.
     </title>
@@ -7869,7 +7869,7 @@
      </date>
     </imprint>
    </item>
-   <item n="368" xml:id="Pravitelstvennyj_vestnik_1889_e">
+   <item n="368" xml:id="Pravitelstvennyj_vestnik_1889_d">
     <title type="main">
      Правительственный вестник. 1889. № 59 от 16 марта.
     </title>
@@ -8129,7 +8129,7 @@
      </date>
     </imprint>
    </item>
-   <item n="379" xml:id="Rezener_Azbuka_gr_L_N_Tolstogo_1873_b">
+   <item n="379" xml:id="Rezener_Azbuka_gr_L_N_Tolstogo_1873_a">
     <title type="main">
      Резенер. Азбука гр. Л. Н. Толстого.
     </title>
@@ -8541,7 +8541,7 @@
      </date>
     </imprint>
    </item>
-   <item n="398" xml:id="Sankt_Peterburgskie_vedomosti_1863_b">
+   <item n="398" xml:id="Sankt_Peterburgskie_vedomosti_1863_a">
     <title type="main">
      Санкт-Петербургские ведомости. 1863. № 145 от 28 июня.
     </title>
@@ -8935,7 +8935,7 @@
      </date>
     </imprint>
    </item>
-   <item n="416" xml:id="Skajler_E_Gr_L_N_Tolstoj_1890_b">
+   <item n="416" xml:id="Skajler_E_Gr_L_N_Tolstoj_1890_a">
     <title type="main">
      Скайлер Е. Гр. Л. Н. Толстой.
     </title>
@@ -9340,7 +9340,7 @@
      </date>
     </imprint>
    </item>
-   <item n="433" xml:id="Strahov_Nikolaj_Nikolaevich_Zakonomernost_stihij_i_ponjatij_1885_b">
+   <item n="433" xml:id="Strahov_Nikolaj_Nikolaevich_Zakonomernost_stihij_i_ponjatij_1885_a">
     <title type="main">
      Страхов Н. Н. Закономерность стихий и понятий.
     </title>
@@ -9390,7 +9390,7 @@
      </date>
     </imprint>
    </item>
-   <item n="435" xml:id="Strahov_Nikolaj_Nikolaevich_Kritika_Vojna_i_mir_Soch_gr_L_N_Tolstogo_1869_b">
+   <item n="435" xml:id="Strahov_Nikolaj_Nikolaevich_Kritika_Vojna_i_mir_Soch_gr_L_N_Tolstogo_1869_a">
     <title type="main">
      Страхов Н. Н. Критика. «Война и мир». Соч. гр. Л. Н. Толстого.
     </title>
@@ -9465,7 +9465,7 @@
      </date>
     </imprint>
    </item>
-   <item n="438" xml:id="Strahov_Nikolaj_Nikolaevich_Pismo_k_Danilevskomu_N_Ja_1901_b">
+   <item n="438" xml:id="Strahov_Nikolaj_Nikolaevich_Pismo_k_Danilevskomu_N_Ja_1901_a">
     <title type="main">
      Страхов Н. Н. Письмо к Данилевскому Н. Я.
     </title>
@@ -9562,7 +9562,7 @@
      </date>
     </imprint>
    </item>
-   <item n="442" xml:id="Strahov_Nikolaj_Nikolaevich_Tri_pisma_o_spiritizme_1876_b">
+   <item n="442" xml:id="Strahov_Nikolaj_Nikolaevich_Tri_pisma_o_spiritizme_1876_a">
     <title type="main">
      Страхов Н. Н. Три письма о спиритизме.
     </title>
@@ -9587,7 +9587,7 @@
      </date>
     </imprint>
    </item>
-   <item n="443" xml:id="Strahov_Nikolaj_Nikolaevich_Tri_pisma_o_spiritizme_1876_c">
+   <item n="443" xml:id="Strahov_Nikolaj_Nikolaevich_Tri_pisma_o_spiritizme_1876_b">
     <title type="main">
      Страхов Н. Н. Три письма о спиритизме.
     </title>
@@ -9612,7 +9612,7 @@
      </date>
     </imprint>
    </item>
-   <item n="444" xml:id="Strahov_Nikolaj_Nikolaevich_Tri_pisma_o_spiritizme_1876_d">
+   <item n="444" xml:id="Strahov_Nikolaj_Nikolaevich_Tri_pisma_o_spiritizme_1876_c">
     <title type="main">
      Страхов Н. Н. Три письма о спиритизме.
     </title>
@@ -10891,7 +10891,7 @@
      </date>
     </imprint>
    </item>
-   <item n="497" xml:id="Tulskie_gubernskie_vedomosti_1866_b">
+   <item n="497" xml:id="Tulskie_gubernskie_vedomosti_1866_a">
     <title type="main">
      Тульские губернские ведомости. 1866. № 47 от 19 ноября.
     </title>
@@ -11297,7 +11297,7 @@
      </date>
     </imprint>
    </item>
-   <item n="516" xml:id="Ukazatel_po_delam_pechati_1877_b">
+   <item n="516" xml:id="Ukazatel_po_delam_pechati_1877_a">
     <title type="main">
      Указатель по делам печати. 1877. № 18 от 1 октября.
     </title>
@@ -12710,7 +12710,7 @@
      </date>
     </imprint>
    </item>
-   <item n="575" xml:id="Ashevskij_S_Jasnaja_Poljana_L_Tolstogo_v_kritike_60_h_godov_1913_b">
+   <item n="575" xml:id="Ashevskij_S_Jasnaja_Poljana_L_Tolstogo_v_kritike_60_h_godov_1913_a">
     <title type="main">
      Ашевский С. «Ясная Поляна» Л. Толстого в критике 60-х годов
     </title>

--- a/tolstoy-bio/requirements.txt
+++ b/tolstoy-bio/requirements.txt
@@ -12,3 +12,4 @@ soupsieve==2.5
 tqdm==4.66.2
 urllib3==2.2.1
 webencodings==0.5.1
+transliterate==1.10.2

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/main.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/main.py
@@ -43,6 +43,10 @@ def main():
 
     # print("\n".join([source.id for source in sources]))
 
+    assert len(sources) == len(
+        set(source.id for source in sources)
+    ), "Duplicate source IDs found."
+
     assert all(source.id[0].isalpha() for source in sources), [
         source.id for source in sources if not source.id[0].isalpha()
     ]

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/main.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/main.py
@@ -1,0 +1,57 @@
+from argparse import ArgumentParser
+import os
+
+from tolstoy_bio.bibllist_bio.creating_source_list.source_provider import SourceProvider
+from tolstoy_bio.bibllist_bio.creating_source_list.source_id_generator import (
+    SourceIdGenerator,
+)
+from tolstoy_bio.bibllist_bio.creating_source_list.source_xml_entity_builder import (
+    XmlSourceListBuilder,
+)
+
+
+SOURCE_LIST_XML_PATH = os.path.join(
+    os.path.dirname(__file__), "../../../../reference/sourceList.xml"
+)
+
+
+def main():
+    print("Parsing arguments...")
+
+    cli = ArgumentParser()
+    cli.add_argument("-t", "--table", type=str, default=None)
+    cli.add_argument("-s", "--sheet", type=str, default=None)
+
+    arguments = cli.parse_args()
+
+    excel_table_path = arguments.table
+    excel_table_sheet_name = arguments.sheet
+
+    if not excel_table_path:
+        raise ValueError("Table path is required in system arguments.")
+
+    print(f"Parsing excel table from path {excel_table_path}...")
+
+    sources = SourceProvider.read_sources_from_excel_table(
+        excel_table_path, excel_table_sheet_name
+    )
+
+    source_id_generator = SourceIdGenerator()
+
+    for source in sources:
+        source.set_id(source_id_generator.generate(source))
+
+    # print("\n".join([source.id for source in sources]))
+
+    assert all(source.id[0].isalpha() for source in sources), [
+        source.id for source in sources if not source.id[0].isalpha()
+    ]
+
+    xml_builder = XmlSourceListBuilder(sources)
+
+    xml_builder.build_soup()
+    xml_builder.save_as_xml(SOURCE_LIST_XML_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source-list-template.xml
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source-list-template.xml
@@ -1,0 +1,42 @@
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Источники Гусева</title>
+                <respStmt>
+                    <resp>Идея, постановка задач, руководство</resp>
+                    <name>
+                        Анастасия Бонч-Осмоловская, Фёкла Толстая, Борис Орехов, Тимофей Лукашевский
+                    </name>
+                </respStmt>
+                <respStmt>
+                    <resp>
+                        Подготовка TEI/XML
+                    </resp>
+                    <name>
+                        Мария Картышева, Евгений Можаев, Даниил Скоринкин, Елена Сидорова, Вероника Файнберг, Кирилл Милинцевич, Лев Буланов, Макар Федоров, Константин Петров
+                    </name>
+                </respStmt>
+                <funder>
+                    Проект «Слово Толстого»
+                </funder>
+            </titleStmt>
+            <publicationStmt>
+                <publisher>
+                    <orgName>
+                        Центр Digital Humanities НИУ ВШЭ, Научно-образовательный союз «Родное Слово», проект «Слово Толстого»
+                    </orgName>
+                </publisher>
+                <availability>
+                    <p>
+                        Тексты и метатекстовая разметка доступны для свободного использования и распространения по лицензии Creative Commons Attribution Share-Alike (cc by-sa)
+                    </p>
+                </availability>
+                <date from="2015" to="2022"/>
+            </publicationStmt>
+        </fileDesc>
+    </teiHeader>
+    <standOff>
+        <list/>
+    </standOff>
+</TEI>

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source.py
@@ -1,0 +1,105 @@
+class Source:
+    _index: str | None = None
+    _id: str | None = None
+    _main_title: str | None
+    _bibliographic_title: str | None
+    _author: str | None
+    _editor: str | None
+    _work: str | None
+    _anthology: str | None
+    _publisher: str | None
+    _volume: str | None
+    _publication_place: str | None
+    _publication_date: str | None
+    _storage: str | None
+
+    def __init__(
+        self,
+        index: str | None,
+        main_title: str | None,
+        bibliographic_title: str | None,
+        author: str | None,
+        editor: str | None,
+        work: str | None,
+        anthology: str | None,
+        publisher: str | None,
+        volume: str | None,
+        publication_place: str | None,
+        publication_date: str | None,
+        storage: str | None,
+        id: str | None = None,
+    ):
+        self._index = index
+        self._id = id
+        self._main_title = main_title.strip() or None
+        self._bibliographic_title = bibliographic_title.strip() or None
+        self._author = author.strip() or None
+        self._editor = editor.strip() or None
+        self._work = work.strip() or None
+        self._anthology = anthology.strip() or None
+        self._publisher = publisher.strip() or None
+        self._volume = volume.strip() or None
+        self._publication_place = publication_place.strip() or None
+        self._publication_date = publication_date.strip() or None
+        self._storage = storage.strip() or None
+
+    def __repr__(self):
+        return f"Source(index={self.index}, id={self.id}, main_title={self.main_title}, bibliographic_title={self.bibliographic_title}, author={self.author}, editor={self.editor}, work={self.work}, anthology={self.anthology}, publisher={self.publisher}, volume={self.volume}, publication_place={self.publication_place}, publication_date={self.publication_date}, storage={self.storage})"
+
+    @property
+    def index(self) -> str | None:
+        return self._index
+
+    @property
+    def id(self) -> str | None:
+        return self._id
+
+    @property
+    def main_title(self) -> str | None:
+        return self._main_title
+
+    @property
+    def bibliographic_title(self) -> str | None:
+        return self._bibliographic_title
+
+    @property
+    def author(self) -> str | None:
+        return self._author
+
+    @property
+    def editor(self) -> str | None:
+        return self._editor
+
+    @property
+    def work(self) -> str | None:
+        return self._work
+
+    @property
+    def anthology(self) -> str | None:
+        return self._anthology
+
+    @property
+    def publisher(self) -> str | None:
+        return self._publisher
+
+    @property
+    def volume(self) -> str | None:
+        return self._volume
+
+    @property
+    def publication_place(self) -> str | None:
+        return self._publication_place
+
+    @property
+    def publication_date(self) -> str | None:
+        return self._publication_date
+
+    @property
+    def storage(self) -> str | None:
+        return self._storage
+
+    def set_id(self, id: str) -> None:
+        if self._id is not None:
+            raise ValueError("Source id cannot be changed after being set.")
+
+        self._id = id

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source_id_generator.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source_id_generator.py
@@ -99,7 +99,7 @@ class SourceIdGenerator:
         )
 
     def _make_id_unique(self, base_id: str, count_to_be: int):
-        postfix_letter_index = count_to_be - 1
+        postfix_letter_index = count_to_be - 2
 
         assert postfix_letter_index < len(latin_alphabet_letters), (
             f"Invalid count to be: {count_to_be}, "

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source_id_generator.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source_id_generator.py
@@ -1,0 +1,111 @@
+import re
+from string import ascii_lowercase as latin_alphabet_letters
+
+from transliterate import translit
+
+from tolstoy_bio.bibllist_bio.creating_source_list.source import Source
+from tolstoy_bio.utilities.function import FunctionUtils
+
+
+def transliterate_cyrillic_text(text: str) -> str:
+    return translit(text, "ru", reversed=True)
+
+
+def remove_soft_sign_transliterations(text: str) -> str:
+    return re.sub(r"'", "", text)
+
+
+def replace_non_alphanumeric_characters_with_space(text: str):
+    return re.sub(r"[^a-zA-Z0-9а-яёА-ЯЁ]", " ", text)
+
+
+def trim_space_sequences(string: str):
+    return re.sub("\s+", " ", string).strip()
+
+
+def join_strings_by_space(strings: list[str]):
+    return " ".join(strings)
+
+
+def convert_items_to_strings(items: list):
+    return [str(item) for item in items]
+
+
+def replace_spaces_with_underscores(string: str):
+    return re.sub("\s+", "_", string)
+
+
+class SourceIdGenerator:
+    _generated_id_counts: dict[str, int]
+
+    def __init__(self):
+        self._generated_id_counts = {}
+
+    def generate(self, source: Source) -> str:
+        try:
+            return self._generate_unique_id_from_source(source)
+        except AssertionError as e:
+            return f"NONE: {source.index}"
+
+    def _generate_unique_id_from_source(self, source: Source) -> str:
+        base_id = self._generate_base_id_from_source(source)
+
+        duplicate_count = self._generated_id_counts.get(base_id, 0)
+
+        if duplicate_count > 0:
+            duplicate_count_to_be = duplicate_count + 1
+            unique_id = self._make_id_unique(base_id, duplicate_count_to_be)
+
+            self._generated_id_counts[base_id] = duplicate_count_to_be
+
+            return unique_id
+
+        self._generated_id_counts[base_id] = 1
+        return base_id
+
+    @classmethod
+    def _generate_base_id_from_source(cls, source: Source) -> str:
+        components = [
+            source.author,
+            "Былое" if source.index == "66" else (source.work or source.anthology),
+            source.publication_date,
+        ]
+
+        existent_components = [component for component in components if component]
+
+        if len(existent_components) == 0 or (
+            len(existent_components) == 1
+            and existent_components[0] == source.publication_date
+        ):
+            raise AssertionError(
+                f"Insufficient number of components to generate the semantic id for {source}"
+            )
+
+        return cls._generate_base_id_from_components(*existent_components)
+
+    @staticmethod
+    def _generate_base_id_from_components(*components: tuple[str]) -> str:
+        return FunctionUtils.pipe(
+            components,
+            (
+                convert_items_to_strings,
+                join_strings_by_space,
+                replace_non_alphanumeric_characters_with_space,
+                trim_space_sequences,
+                transliterate_cyrillic_text,
+                replace_spaces_with_underscores,
+                remove_soft_sign_transliterations,
+            ),
+        )
+
+    def _make_id_unique(self, base_id: str, count_to_be: int):
+        postfix_letter_index = count_to_be - 1
+
+        assert postfix_letter_index < len(latin_alphabet_letters), (
+            f"Invalid count to be: {count_to_be}, "
+            f"there are only {len(latin_alphabet_letters)} letters in the latin alphabet {self._generated_id_counts}"
+        )
+
+        postfix_letter = latin_alphabet_letters[postfix_letter_index]
+
+        return f"{base_id}_{postfix_letter}"

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source_provider.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source_provider.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from tqdm import tqdm
+
+from tolstoy_bio.bibllist_bio.creating_source_list.source import Source
+
+
+class SourceProvider:
+    @staticmethod
+    def read_sources_from_excel_table(
+        excel_table_path: str, sheet_name: str | None = None
+    ) -> list[Source]:
+        table = pd.read_excel(excel_table_path, sheet_name=sheet_name, dtype=str)
+
+        table.fillna("", inplace=True)
+
+        return [
+            Source(
+                index=entry["Unnamed: 0"],
+                main_title=entry["title_main"],
+                bibliographic_title=entry["title_bibl"],
+                author=entry["автор"],
+                editor=entry["редактор"],
+                work=entry["заголовок работы"],
+                anthology=entry["опубликова в"],
+                publisher=entry["издатнльство "],
+                volume=entry["том, книга, выпуск"],
+                publication_place=entry["место издания"],
+                publication_date=entry["дата издания"],
+                storage=entry["место хранения"],
+            )
+            for _, entry in tqdm(
+                table.iterrows(), "Parsing sources from XLSX table", len(table)
+            )
+        ]

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source_xml_entity_builder.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/creating_source_list/source_xml_entity_builder.py
@@ -1,0 +1,105 @@
+import os
+from typing import Self
+import bs4
+from tqdm import tqdm
+
+from tolstoy_bio.bibllist_bio.creating_source_list.source import Source
+from tolstoy_bio.utilities.beautiful_soup import BeautifulSoupUtils
+
+
+SOURCE_LIST_XML_TEMPLATE_PATH = os.path.join(
+    os.path.dirname(__file__), "source-list-template.xml"
+)
+
+
+class XmlElement:
+    def __init__(self, soup: bs4.Tag):
+        self._soup = soup
+
+    def append_element(
+        self, name: str, attributes: dict[str, str] = {}, inner_text: str = None
+    ) -> Self:
+        soup = bs4.BeautifulSoup(features="xml")
+        tag = soup.new_tag(name, attrs=attributes)
+
+        if inner_text:
+            tag.string = soup.new_string(inner_text)
+
+        self._soup.append(tag)
+
+        return XmlElement(tag)
+
+    def append_element_if_has_inner_text(
+        self, name: str, attributes: dict[str, str] = {}, inner_text: str | None = None
+    ) -> None:
+        if not inner_text:
+            return
+
+        return self.append_element(name, attributes, inner_text)
+
+    def append_to(self, element: bs4.Tag) -> None:
+        element.append(self._soup)
+
+    def to_soup(self):
+        return self._soup
+
+
+def build_source_xml_entity(source: Source) -> bs4.Tag:
+    soup = bs4.BeautifulSoup(f'<item xml:id="{source.id}" n="{source.index}"/>', "xml")
+
+    item_element = XmlElement(soup.find("item"))
+
+    item_element.append_element_if_has_inner_text(
+        "title", {"type": "main"}, source.main_title
+    )
+
+    item_element.append_element_if_has_inner_text(
+        "title", {"type": "bibl"}, source.bibliographic_title
+    )
+
+    item_element.append_element_if_has_inner_text("author", inner_text=source.author)
+
+    item_element.append_element_if_has_inner_text("editor", inner_text=source.editor)
+
+    item_element.append_element_if_has_inner_text("title", {"level": "a"}, source.work)
+
+    item_element.append_element_if_has_inner_text(
+        "title", {"level": "m"}, source.anthology
+    )
+
+    item_element.append_element_if_has_inner_text("biblScope", {}, source.volume)
+
+    item_element.append_element_if_has_inner_text("repository", {}, source.storage)
+
+    if source.publication_place or source.publisher or source.publication_date:
+        imprint_element = item_element.append_element("imprint")
+
+        imprint_element.append_element_if_has_inner_text(
+            "pubPlace", {}, source.publication_place
+        )
+        imprint_element.append_element_if_has_inner_text(
+            "publisher", {}, source.publisher
+        )
+
+        imprint_element.append_element_if_has_inner_text(
+            "date", {}, source.publication_date
+        )
+
+    return item_element.to_soup()
+
+
+class XmlSourceListBuilder:
+    def __init__(self, sources: list[Source]) -> None:
+        self._soup = BeautifulSoupUtils.create_soup_from_file(
+            SOURCE_LIST_XML_TEMPLATE_PATH, "xml"
+        )
+
+        self._sources = sources
+
+    def build_soup(self) -> bs4.Tag:
+        for source in tqdm(self._sources, "Building XML items"):
+            item_element = build_source_xml_entity(source)
+            self._soup.find("standOff").find("list").append(item_element)
+
+    def save_as_xml(self, path: str):
+        BeautifulSoupUtils.prettify_and_save(self._soup, path)

--- a/tolstoy-bio/tolstoy_bio/utilities/function.py
+++ b/tolstoy-bio/tolstoy_bio/utilities/function.py
@@ -1,0 +1,7 @@
+from functools import reduce
+from typing import Callable
+
+
+class FunctionUtils:
+    def pipe(data, functions: tuple[Callable]):
+        return reduce(lambda x, f: f(x), functions, data)


### PR DESCRIPTION
https://gitlab.slovotolstogo.ru/slovotolstogoprojects/web-support/-/issues/64

1. Сгенерировал айдишники для источников (добавил их в таблицу в столбец ID);
2. Сгенерировал XML (/references/sourceList.xml) c сущностями источников.

**Комментарии**

Айдишники генерировал из трёх компонентов:

1. "автор";
2. "заголовок работы", если он есть, либо "опубликован в";
4. "дата издания".

Если какого-то компонента нет, он пропускается. Если идентичный айдишник уже есть, то к нему добавляется постфикс "\_a", "\_b" и т. д. Нижнее подчёркивание перед постфиксом-буквой добавил, чтобы, если в айдишнике нет года, буква не сливалась со словом.

В рамках MR сгенерировал файл sourceList.xml. Структура похожа на locationList.xml в том плане, что в нём вместо `<text>` выбран тег `<standOff>`. Для контейнера сущностей-источников выбран тег `<list>`, в нём каждая сущность-источник размечается тегом-контейнером `<item>`.

У тега `<item>` есть атрибуты "xml:id" (сгенерированный айдишник источника) и "n" (порядковый номер источника взятый из первого столбца таблицы для удобства отладки, если потребуется).

Внутренняя структура `<item>`:

1. `<title type="main">` – столбец D (title main);
2. `<title type="bibl">` – столбец E (title bibl);
4. `<author>` – столбец G (автор);
5. `<editor>` – столбец H (редактор);
6. `<title level="a">` – столбец I (заголовок работы);
7. `<title level="m">` – столбец J (опубликован в);
8. `<biblScope>` – столбец K (том, книга, выпуск);
9. `<repository>` – столбец O (место хранения);
10. `<imprint>` – тег-контейнер под данные издания:
   1. `<pubPlace>` – столбец M (место издания);
   2. `<publisher>` – столбец L (издательство);
   3. `<date>` – столбец N (дата издания).