### PR TITLE
[Scripts] Collecting Gusev's bibl-tag segments of uncertain type to XLSX

### DIFF
--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/gusev_sources/collect_bibl_segments_of_uncertain_type.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/gusev_sources/collect_bibl_segments_of_uncertain_type.py
@@ -1,0 +1,65 @@
+import os
+
+import pandas as pd
+from tqdm import tqdm
+
+from .document.gusev_tei_repository import GusevTeiRepository
+
+
+DOCUMENT_ID_COLUMN_LABEL = "document_id"
+BIBL_SEGMENT_COLUMN_LABEL = "segment"
+BIBL_SEGMENT_ABSENCE_PLACEHOLDER = "check"
+
+
+def main():
+    collect_bibl_segments_of_uncertain_type()
+
+
+def collect_bibl_segments_of_uncertain_type():
+    gusev_repository = GusevTeiRepository()
+    gusev_documents = gusev_repository.get_documents()
+
+    table_entries = []
+
+    for document in tqdm(gusev_documents, "Collecting table data"):
+        bibl_elements = document.get_bibl_elements()
+
+        for bibl_element in bibl_elements:
+            bibl_text = bibl_element.get_text()
+            bibl_text_segments = bibl_text.get_segments()
+
+            for segment in bibl_text_segments:
+                if (
+                    segment.has_uncertain_type()
+                    and segment.get_text() != BIBL_SEGMENT_ABSENCE_PLACEHOLDER
+                ):
+                    table_entries.append(
+                        {
+                            DOCUMENT_ID_COLUMN_LABEL: document.get_id(),
+                            BIBL_SEGMENT_COLUMN_LABEL: segment.get_text(),
+                        }
+                    )
+
+    sorted_table_entries = sorted(
+        table_entries,
+        key=lambda entry: (
+            entry[DOCUMENT_ID_COLUMN_LABEL],
+            entry[BIBL_SEGMENT_COLUMN_LABEL],
+        ),
+    )
+
+    table = pd.DataFrame(
+        sorted_table_entries,
+        columns=[DOCUMENT_ID_COLUMN_LABEL, BIBL_SEGMENT_COLUMN_LABEL],
+    )
+
+    table.to_excel(
+        os.path.join(
+            os.path.dirname(__file__), "data/gusev_bibl_segments_of_uncertain_type.xlsx"
+        ),
+        index=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/gusev_sources/document/gusev_bibl_text_segment.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/gusev_sources/document/gusev_bibl_text_segment.py
@@ -32,10 +32,6 @@ class GusevBiblTextSegment:
             detected_types.append(GusevSourceType.TOLSTOY_LETTER)
 
         return detected_types
-    
+
     def has_uncertain_type(self) -> bool:
-        if self.text in ["Д", "ДСТ", "ЕСТ", "ЯЗ", "Гольд", "Юб.", "Юб"]:
-            return True
-        
-        types: list = self.get_source_types()
-        return len(types) == 0
+        return not self.get_source_types()

--- a/tolstoy-bio/tolstoy_bio/bibllist_bio/gusev_sources/main.py
+++ b/tolstoy-bio/tolstoy_bio/bibllist_bio/gusev_sources/main.py
@@ -141,54 +141,5 @@ def generate_json_with_counted_segments_by_item_type() -> None:
     )
 
 
-def get_non_tolstoy_bio_bibl_segments():
-    gusev_repository = GusevTeiRepository()
-    gusev_documents = gusev_repository.get_documents()
-
-    @dataclass
-    class Segment:
-        document_id: str
-        text: str
-
-        def __hash__(self):
-            return hash(self.text)
-
-        def __eq__(self, other) -> bool:
-            return self.text == other.text
-
-    segments: set[Segment] = set()
-
-    for document in tqdm(gusev_documents, "Getting non-tolstoy-bio <bibl> segments"):
-        bibl_elements = document.get_bibl_elements()
-
-        for bibl_element in bibl_elements:
-            bibl_text = bibl_element.get_text()
-            bibl_text_segments = bibl_text.get_segments()
-
-            for segment in bibl_text_segments:
-                if segment.has_uncertain_type():
-                    segments.add(
-                        Segment(
-                            document_id=document.get_id(),
-                            text=segment.get_text(),
-                        )
-                    )
-
-    sorted_segments = sorted(segments, key=lambda segment: segment.text)
-
-    print(sorted_segments)
-
-    df = pd.DataFrame(sorted_segments, columns=["document_id", "text"])
-
-    print(df)
-
-    df.to_excel(
-        os.path.join(
-            os.path.dirname(__file__), "data/non_tolstoy_bio_bibl_segments.xlsx"
-        ),
-        index=False,
-    )
-
-
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Изменения касаются только кодовой базы по скриптам. Добавляю в репозиторий на случай необходимости переиспользовать в дальнейшем. Этот скрипт использовался для генерации XLSX-таблицы со списком сегментов bibl-тегов в документах Гусева, которые не удалось достоверно классифицировать в ходе первичной перелинковки Гусевских документов с документами tolstoy-bio. Итоговая таблица отправлена @abonch 27-го марта 2025-го.